### PR TITLE
Strava upload - Activity Title - Route name

### DIFF
--- a/src/features/form-post/impl-requestlib.unit.test.js
+++ b/src/features/form-post/impl-requestlib.unit.test.js
@@ -1,4 +1,5 @@
 const RequestForm = require("./impl-requestlib")
+const fs = require('fs/promises')
 
 const testOpts = {
     url: 'https://www.strava.com/api/v3/uploads',
@@ -17,16 +18,69 @@ const uploadInfo =  {
     external_id: '2b498cb0-2241-4cf0-9f77-0279adca2851-1702733150888'
 }
 
+// Mock fs.readFile for tests
+jest.mock('fs/promises');
 
-describe( 'FormPost Feature: RequestLib Implementation',()=>{
+describe('FormPost Feature: RequestLib Implementation', () => {
+    beforeEach(() => {
+        // Reset all mocks before each test
+        jest.clearAllMocks();
+    });
 
-    describe ('createForm',()=>{
-        test('normal request',async ()=>{
+    describe('createForm', () => {
+        test('normal request', async () => {
             const c = new RequestForm()
-            const res = await c.createForm(testOpts,uploadInfo)
-            
+            const res = await c.createForm(testOpts, uploadInfo)
             expect(res).toMatchSnapshot()
-
         })
+
+        test('should use route name from JSON file', async () => {
+            // Mock the JSON file content
+            const mockJsonContent = JSON.stringify({
+                route: {
+                    name: 'Test Route Name'
+                }
+            });
+            
+            fs.readFile.mockImplementation((path, encoding) => {
+                if (path.endsWith('.json')) {
+                    return Promise.resolve(mockJsonContent);
+                }
+                return Promise.resolve('mock file content');
+            });
+
+            const testUploadInfo = {
+                ...uploadInfo,
+                file: {
+                    type: 'file',
+                    fileName: 'testdata/activity.tcx'
+                }
+            };
+
+            const c = new RequestForm();
+            const res = await c.createForm(testOpts, testUploadInfo);
+
+            // Verify the name was updated with the route name and suffix
+            expect(res.formData.name).toBe('Test Route Name - Incyclist Ride');
+        });
+
+        test('should fallback to default name if JSON file not found', async () => {
+            // Mock fs.readFile to throw an error
+            fs.readFile.mockRejectedValue(new Error('File not found'));
+
+            const testUploadInfo = {
+                ...uploadInfo,
+                file: {
+                    type: 'file',
+                    fileName: 'testdata/activity.tcx'
+                }
+            };
+
+            const c = new RequestForm();
+            const res = await c.createForm(testOpts, testUploadInfo);
+
+            // Verify fallback to default name
+            expect(res.formData.name).toBe('Incyclist Ride');
+        });
     })
 }) 


### PR DESCRIPTION
When activity is uploaded to strava it uses Route name as Title. At the moment each upload to strava contains only "Incyclist Ride". Now it will be "Free Ride - Incyclist Ride" for free ride. Or for example "DeMeinweg - Incyclist Ride".

"Rioja 3 - Fitero" was first test. That's why it doesn't have "Incyclist Ride".
![Strava_Route_Name](https://github.com/user-attachments/assets/9cfc678e-5dec-428b-a93c-e79d356f65e6)
