### PR TITLE
chore: upgrade Electron to v43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "axios-mock-adapter": "^2.1.0",
         "bindings": "^1.5.0",
         "dotenv": "^17.3.1",
-        "electron": "^37.10.3",
+        "electron": "^43.1.0",
         "electron-builder": "^26.8.1",
         "form-data": "^4.0.5",
         "incyclist-devices": "^3.0.9",
@@ -1160,6 +1160,16 @@
       },
       "engines": {
         "node": ">= 14.17.5"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -6554,22 +6564,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "37.10.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
-      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
+      "integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -7284,71 +7294,55 @@
       }
     },
     "node_modules/electron/node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
       }
     },
-    "node_modules/electron/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/electron/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "engines": {
-        "node": ">=6 <7 || >=8"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/electron/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/electron/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -13898,6 +13892,17 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "axios-mock-adapter": "^2.1.0",
     "bindings": "^1.5.0",
     "dotenv": "^17.3.1",
-    "electron": "^37.10.3",
+    "electron": "^43.1.0",
     "electron-builder": "^26.8.1",
     "form-data": "^4.0.5",
     "incyclist-devices": "^3.0.9",
@@ -84,5 +84,4 @@
     "tar": "^7.4.3",
     "tmp": "^0.2.3"
   }
-
 }

--- a/src/app.js
+++ b/src/app.js
@@ -42,7 +42,7 @@ class IncyclistApp
         this.environment  = process.env.ENVIRONMENT ?? "prod";
         
         app.incyclistApp = this
-        app.allowRendererProcessReuse=false;  
+
         if (process.platform==='darwin') {
             Menu.setApplicationMenu(null);
         }
@@ -131,7 +131,7 @@ class IncyclistApp
 
         app.on('before-quit', (e)=> this.onBeforeQuit(e))
         app.on('will-quit', (e) => this.onWillQuit(e))
-        app.on('session-created', (_event,session) => this.onSessionCreated(session) )
+        app.on('session-created', (session) => this.onSessionCreated(session) )
 
         ipcMain.on ('app-broadcast',this.onAppBroadcast.bind(this) )
         ipcMain.on ('errorInWindow',(event,source,err)=>this.onCrash(event,source,err) )

--- a/src/web/pages/main.js
+++ b/src/web/pages/main.js
@@ -56,7 +56,7 @@ class MainWindow {
             minHeight:600,
             useContentSize :true,
             allowRunningInsecureContent :true,
-            enableRemoteModule:false,
+
             resizable:true,
             webPreferences: {
                 webSecurity:false, 


### PR DESCRIPTION
## Summary

- Bump `electron` devDependency from `^37.10.3` to `^43.1.0` (installs 43.1.0)
- Remove `app.allowRendererProcessReuse = false` — property was removed in Electron 14, was dead code
- Remove `enableRemoteModule: false` from `BrowserWindow` webPreferences — option was removed in Electron 14, was dead code
- Fix `session-created` event handler signature: the event emits `(session)` not `(event, session)`, so `onSessionCreated` was previously receiving `undefined`

Breaking changes in Electron 38–43 were reviewed; none of the removed/deprecated APIs (`plugin-crashed`, clipboard-in-renderer, `clearStorageData` quotas, `webFrame.routingId`, `showHiddenFiles` on Linux) are used in this codebase.

## Test plan

- [x] `npm test` — all 117 tests pass
- [x] `npm run dev` — app launches and renderer loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)