### PR TITLE
feat: replace bundled secrets.json with OS-encrypted secret provisioning

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -19,11 +19,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Retrieve the secret and write it to a file
-      env:
-        SECRET_FILE: ${{ secrets.SECRET_FILE }}
-      run: |
-        echo $SECRET_FILE > ./src/secrets.json
 
     - name: Install snapcraft
       run: sudo snap install snapcraft --classic        

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -20,11 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Retrieve the secret and write it to a file
-      env:
-        SECRET_FILE: ${{ secrets.SECRET_FILE }}
-      run: |
-        echo $SECRET_FILE > ./src/secrets.json
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -22,14 +22,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Retrieve the secret and write it to a file
-      shell: pwsh    
-      env:
-        SECRET_FILE: ${{ secrets.SECRET_FILE }}
-      run: |
-        $env:SECRET_FILE | Out-File .\src\secrets.json        
-        dir .\src
-
     - name: Retrieve the settings and write them to a file
       shell: pwsh    
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ workspace.*
 .log-*
 settings.json
 logfile.json
+src/.settings/
 **/secrets.json
 app/.settings/
 bin/*/ergoapp.node

--- a/README.MD
+++ b/README.MD
@@ -4,54 +4,21 @@ This repository contains the main app of the [Incyclist](https://incyclist.com) 
 
 ## Running the app
 
-### Requirements
+### Normal run
 
-Incyclist depends on a couple of external services. Although the app will work without any of those services, some parts of the application might be impacted if those services are not correctly configured. 
+```bash
+npm start
+```
 
-Therefore, the credentials to access those services have to be configured:
+In principle, Electron developer tools can be opened at any time with `CTRL+SHIFT+ALT+I`, though this shortcut has not been reliable on Linux in recent releases.
 
-Create a file secrets.json in the [./src](./src) folder. This file needs to contain the following information
+### Development run
 
-#### Message Queue Broker
+```bash
+npm run dev
+```
 
-Incyclist uses a Message Queue to manage group rides. You either need to request credentials via our Slack workspace, or you need to setup your own MQTT Message Broker
-
-_MQ_BROKER_ URL of the Message Queue Broker (required for group ride support) 
-
-_MQ_USER_ , _MQ_PASSWORD_  Credentials to to be used to authenticate against the Message Queue Broker
-
-#### JAWG API Keys
-
-The [JAWG Elevation API](https://www.jawg.io/en/) is used to update elevation profiles, when generating routes. In order to request credentials, got to their web site
-
-_JAWG_API_KEY_  API key for the [JAWG Elevation API](https://www.jawg.io/en/)
-
-#### Google Maps API Keys
-
-The Google Maps Api Keys are used to present Street View or Sattelite View during ride. In order to request credentials, visit the Google Maps web site
-
-_GOOGLE_API_KEY_ API Key for [Google Maps API](https://developers.google.com/maps)
-
-#### Strava API Keys
-
-The Strava API is used to connect with the Strava service and upload activities after finishing a ride. In order to request credentials, visit the Strava developer web site
-
-_STRAVA_CLIENT_ID_,  _STRAVA_CLIENT_SECRET_ Credentials for the [Strava API](https://developers.strava.com/)
-
-#### Incyclist API Keys
-
-The Incyclist API is used to fro various operations ( e.g. automatic update, getting routes and videos, getting group rides,....). In order to request credentials, contact us via the Incyclist Slack workspace
-
-_INCYCLIST_API_KEY_ Incyclist API Key
-
-
-### Starting
-
-`> npm start`
-
-### Using Electron Developer Tools
-
-Once the app is started, you can press CTRL+SHIFT+ALT+I to open the Electron Developer Tools.
+Starts the app with Electron developer tools opened automatically. Use this when actively working on the app.
 
 
 ## Building the Installers

--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,8 @@ const os = require('node:os');
 const RestLogAdapter = require('./modules/RestLogAdapter')
 const {checkDir,deleteFile,getLogDirectory,gnerateUUID} = require( './utils')
 const AutoUpdate = require('./modules/AutoUpdate')
-const {initFeaturesApp} = require('./features'); 
+const {initFeaturesApp} = require('./features');
+const SecretsFeature = require('./features/secrets/feature');
 const AppSettings  = require('./features/AppSettings');
 const { restLogFilter, fileLogFilter } = require('./utils/logging');
 
@@ -144,7 +145,8 @@ class IncyclistApp
         }
 
         this.logger.logEvent({message:'app event',event:'ready', electron:process.versions.electron})
-        initFeaturesApp( {logger:this.logger} )           
+        await SecretsFeature.getInstance().init({ timeout: 5000 })
+        initFeaturesApp( {logger:this.logger} )
         this.windowManager.showLoadingWindow()
         this.checkForUpdates()
 

--- a/src/features/AppSettings.js
+++ b/src/features/AppSettings.js
@@ -5,7 +5,6 @@ const { EventLogger } = require( 'gd-eventlog')
 const path = require('path')
 const os = require('os');
 const fs = require('fs')
-const { getSecret } = require('../modules/secrets.js')
 const { getRealCPUArchitecture } = require('../utils/architecture.js')
 
 const SAVE_INTERVAL = 3000;
@@ -95,15 +94,6 @@ class AppSettings {
     
     
     
-    getSecretValue(event,callId, key, defValue ) {
-        const value = getSecret(key) || defValue;
-        if ( event) {
-            ipcResponse(event.sender,'appSettings-getSecret',callId,value)
-        }
-    }
-    
-        
-
     static getValue ( settings, key, defValue ) {
         const clone = (obj) => JSON.parse(JSON.stringify(obj));
         const valid = (v) => v!==undefined && v!==null;
@@ -625,7 +615,6 @@ class AppSettings {
         ipcMain.on('appSettings-save',(event,callId,values) => settings.saveRequest(event,callId,values));
         ipcMain.on('appSettings-overwrite',(event,callId,values) => settings.overwriteRequest(event,callId,values));
         ipcMain.on('appSettings-getOS',(event,callId) => settings.getOS(event,callId));
-        ipcMain.on('appSettings-getSecret',(event,callId,key,defValue) => settings.getSecretValue(event,callId,key,defValue));
 
         ipcHandleSync('appSettings-getOSSync',()=>settings.getOSSync(),ipcMain)
         ipcHandleSync('appSettings-getAppInfo',getAppInfo,ipcMain)
@@ -642,13 +631,12 @@ class AppSettings {
         spec.appSettings.save        = ipcCall('appSettings-save',ipcRenderer,{debug})
         spec.appSettings.overwrite   = ipcCall('appSettings-overwrite',ipcRenderer,{debug})
         spec.appSettings.getOS       = ipcCall('appSettings-getOS',ipcRenderer,{debug})
-        spec.appSettings.getSecret   = ipcCall('appSettings-getSecret',ipcRenderer,{debug})
 
         spec.appSettings.getOSSync   = ipcCallSync('appSettings-getOSSync',ipcRenderer,{debug})
         spec.appSettings.getAppInfo  = ipcCallSync('appSettings-getAppInfo',ipcRenderer,{debug})
 
         spec.registerFeatures( [
-            'appSettings' , 'appSettings.secret' , 'appSettings.os', 'appSettings.os.v2', 'appSettings.secret.v2', 'appSettings.appInfo', 'appSettings.overwrite',
+            'appSettings', 'appSettings.os', 'appSettings.os.v2', 'appSettings.appInfo', 'appSettings.overwrite',
         ] )
     }
    

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,3 +1,4 @@
+const SecretsFeature = require('./secrets/feature').getInstance();
 const FormPost = require('./form-post').getInstance();
 const FileSelection = require('./FileSelection')
 const IncyclistScheme = require('./IncyclistScheme')
@@ -18,9 +19,10 @@ const Crypto = require('./crypto').getInstance()
 const {ObserverHandler} = require('./utils/observer')
 
 function initFeaturesApp( props ) {
-    
+
     ObserverHandler.getInstance().register()
 
+    SecretsFeature.register(props);
     FileSelection.register(props);
     IncyclistScheme.register(props);
     VideoScheme.register(props);
@@ -58,6 +60,7 @@ function initFeaturesWeb( electron,ipcRenderer) {
     electron.registerFeature('ipc-samems-fix')
 
     // New API
+    SecretsFeature.registerRenderer(electron,ipcRenderer);
     FileSelection.registerRenderer(electron,ipcRenderer)
     IncyclistScheme.registerRenderer(electron,ipcRenderer)
     FormPost.registerRenderer(electron,ipcRenderer);

--- a/src/features/mq.js
+++ b/src/features/mq.js
@@ -2,7 +2,7 @@ const {ipcMain} = require('electron');
 const {EventLogger } = require('gd-eventlog');
 const {ipcCall, ipcSendEvent, ipcResponse,isTrue} = require ('./utils/index.js')
 const Feature = require('./base.js')
-const { getSecret } = require('../modules/secrets.js')
+const SecretsFeature = require('./secrets/feature')
 const mqtt = require('mqtt');
 const Prom = require('../utils/promises.js');
 
@@ -27,10 +27,6 @@ class MessageQueueFeature extends Feature{
         this.subscriptions = [];
         this.messages = []
         this.retryCount = 0;
-
-        this.broker = getSecret('MQ_BROKER');
-        this.username = getSecret('MQ_USER');
-        this.password = getSecret('MQ_PASSWORD');
     } 
 
     static getInstance() {
@@ -77,6 +73,17 @@ class MessageQueueFeature extends Feature{
     }
 
     async _doConnect() {
+        this.broker = SecretsFeature.getInstance().getSecret('MQ_BROKER');
+        this.username = SecretsFeature.getInstance().getSecret('MQ_USER');
+        this.password = SecretsFeature.getInstance().getSecret('MQ_PASSWORD');
+
+        if (!this.broker) {
+            if (this.retryCount === 0)
+                this.logger.logEvent({ message: 'MQTT broker not configured — MQ_BROKER secret missing', level: 'warn' });
+            this.connecting = false;
+            return;
+        }
+
         this.retryCount++;
         if( this.retryCount<=1)
             this.logger.logEvent( {message:`connecting to mqtt broker ${this.broker}`});

--- a/src/features/secrets/feature.js
+++ b/src/features/secrets/feature.js
@@ -1,8 +1,8 @@
 const { safeStorage, app, powerMonitor, net, ipcMain } = require('electron')
-const fs = require('fs')
-const path = require('path')
-const crypto = require('crypto')
-const os = require('os')
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
+const os = require('node:os')
 const { EventLogger } = require('gd-eventlog')
 const Feature = require('../base')
 const { ipcHandleSync, ipcCallSync } = require('../utils/index.js')
@@ -54,7 +54,7 @@ class SecretsFeature extends Feature {
         return this.currentStatus;
     }
 
-    async init(opts = { timeout: 5000 }) {
+    async init({ timeout = 5000 } = {}) {
         if (!this._isProd()) {
             this.logger.logEvent({ message: 'skipping secret update', reason: 'non-prod build' });
             this._logDevSecretsSource();
@@ -68,7 +68,7 @@ class SecretsFeature extends Feature {
 
         const result = await Promise.race([
             this.initPromise,
-            new Promise(resolve => setTimeout(() => resolve(this.currentStatus), opts.timeout)),
+            new Promise(resolve => setTimeout(() => resolve(this.currentStatus), timeout)),
         ]);
         this.initPromise = null;
         this._startRetry();

--- a/src/features/secrets/feature.js
+++ b/src/features/secrets/feature.js
@@ -1,0 +1,298 @@
+const { safeStorage, app, powerMonitor, net, ipcMain } = require('electron')
+const fs = require('fs')
+const path = require('path')
+const crypto = require('crypto')
+const os = require('os')
+const { EventLogger } = require('gd-eventlog')
+const Feature = require('../base')
+const { ipcHandleSync, ipcCallSync } = require('../utils/index.js')
+
+const AppSettings = require('../AppSettings');
+
+const TTL_DAYS = 30;
+const RETRY_INTERVAL_MS = 60 * 1000;
+const STATUS_TIMEOUT_MS = 3000;
+const PROVISION_TIMEOUT_MS = 5000;
+const DEFAULT_SECRETS_BASE_URL = 'https://dlws.incyclist.com';
+
+class SecretsFeature extends Feature {
+    static _instance;
+
+    constructor() {
+        super();
+        this.logger = new EventLogger('Secrets');
+        this.currentStatus = 'missing';
+        this.currentSecrets = null;
+        this.initPromise = null;
+        this.retryIv = null;
+        this._pendingVerification = false;
+    }
+
+    static getInstance() {
+        if (!SecretsFeature._instance)
+            SecretsFeature._instance = new SecretsFeature();
+        return SecretsFeature._instance;
+    }
+
+    _isProd() {
+        return (process.env.ENVIRONMENT ?? 'prod') === 'prod';
+    }
+
+    _getBaseUrl() {
+        const fromSettings = AppSettings.getInstance().settings?.SECRET_SERVER_URL;
+        return fromSettings ?? process.env.SECRETS_BASE_URL ?? DEFAULT_SECRETS_BASE_URL;
+    }
+
+    getSecret(key) {
+        if (!this._isProd())
+            return this._getDevSecret(key);
+        return this.currentSecrets ? (this.currentSecrets[key] ?? '') : '';
+    }
+
+    getStatus() {
+        if (!this._isProd()) return 'ok';
+        return this.currentStatus;
+    }
+
+    async init(opts = { timeout: 5000 }) {
+        if (!this._isProd()) {
+            this.logger.logEvent({ message: 'skipping secret update', reason: 'non-prod build' });
+            this._logDevSecretsSource();
+            return 'ok';
+        }
+
+        this.logger.logEvent({ message: 'secrets server', url: this._getBaseUrl() });
+
+        if (!this.initPromise)
+            this.initPromise = this.performInit();
+
+        const result = await Promise.race([
+            this.initPromise,
+            new Promise(resolve => setTimeout(() => resolve(this.currentStatus), opts.timeout)),
+        ]);
+        this.initPromise = null;
+        this._startRetry();
+        return result;
+    }
+
+    async performInit() {
+        try {
+            if (!safeStorage.isEncryptionAvailable()) {
+                this.logger.logEvent({ message: 'safeStorage not available' });
+                this.currentStatus = 'missing';
+                return this.currentStatus;
+            }
+
+            const cache = this._readCache();
+            const isOnline = net.isOnline();
+            const expired = !cache || this._isExpired(cache.fetchedAt);
+
+            this.logger.logEvent({ message: 'secret cache status', cacheStatus: cache ? 'found' : 'null', expired });
+
+            if (expired || !cache) {
+                if (!isOnline) {
+                    this.currentStatus = 'missing';
+                    return this.currentStatus;
+                }
+                return await this._runProvisioning();
+            }
+
+            if (!isOnline) {
+                this.currentSecrets = cache.secrets;
+                this.currentStatus = 'ok';
+                this._pendingVerification = true;
+                return this.currentStatus;
+            }
+
+            return await this._runStatusCheck(cache);
+        } catch (err) {
+            this.logger.logEvent({ message: 'error', fn: 'performInit', error: err.message, stack: err.stack });
+            this.currentStatus = 'missing';
+            return this.currentStatus;
+        }
+    }
+
+    async _runStatusCheck(cache) {
+        try {
+            this.logger.logEvent({ message: 'check secret status' });
+            const apiKey = cache.secrets?.INCYCLIST_API_KEY;
+            const headers = apiKey ? { 'x-api-key': apiKey } : {};
+            const response = await this._fetchWithTimeout(
+                `${this._getBaseUrl()}/api/v1/secrets/status`,
+                { headers },
+                STATUS_TIMEOUT_MS
+            );
+
+            if (response.status === 401)
+                return await this._runProvisioning();
+
+            if (response.ok) {
+                const data = response.data;
+                if (data.valid) {
+                    this.currentSecrets = cache.secrets;
+                } else {
+                    this._writeCache({ secrets: data.secrets, expiresAt: data.expiresAt });
+                    this.currentSecrets = data.secrets;
+                }
+                this.currentStatus = 'ok';
+                this._pendingVerification = false;
+            } else {
+                this.currentSecrets = cache.secrets;
+                this.currentStatus = 'ok';
+                this._pendingVerification = true;
+            }
+        } catch (err) {
+            this.logger.logEvent({ message: 'check secret status failed', reason: err.message });
+            this.currentSecrets = cache.secrets;
+            this.currentStatus = 'ok';
+            this._pendingVerification = true;
+        }
+        return this.currentStatus;
+    }
+
+    _generateAppId(version, osInfo, uuid) {
+        return crypto.createHash('sha256').update(`${version}|${osInfo}|${uuid}`).digest('hex').slice(0, 32);
+    }
+
+    async _runProvisioning() {
+        try {
+            this.logger.logEvent({ message: 'provisioning desktop secrets' });
+            const version = app.getVersion();
+            const osInfo = `${os.platform()}-${os.arch()}`;
+            const uuid = AppSettings.getInstance().settings?.uuid;
+            const appId = this._generateAppId(version, osInfo, uuid);
+
+            const headers = {
+                'x-app-id': appId,
+                'x-app-version': version,
+                'x-os': osInfo,
+                'x-uuid': uuid,
+            };
+
+            const response = await this._fetchWithTimeout(
+                `${this._getBaseUrl()}/api/v1/secrets/desktop`,
+                { method: 'POST', headers },
+                PROVISION_TIMEOUT_MS
+            );
+
+            if (response.ok) {
+                const data = response.data;
+                this._writeCache({ secrets: data.secrets, expiresAt: data.expiresAt });
+                this.currentSecrets = data.secrets;
+                this.currentStatus = 'ok';
+                this._pendingVerification = false;
+            } else {
+                this.logger.logEvent({ message: 'provisioning failed', status: response.status });
+                this.currentStatus = 'missing';
+            }
+        } catch (err) {
+            this.logger.logEvent({ message: 'provisioning failed', reason: err.message });
+            this.currentStatus = 'missing';
+        }
+        this.logger.logEvent({ message: 'provisioning result', secretsStatus: this.currentStatus });
+        return this.currentStatus;
+    }
+
+    _startRetry() {
+        if (this.retryIv) return;
+        this.retryIv = setInterval(async () => {
+            if (this.currentStatus === 'ok' && !this._pendingVerification) return;
+            await this.performInit();
+        }, RETRY_INTERVAL_MS);
+
+        powerMonitor.on('resume', async () => {
+            await this.performInit();
+        });
+    }
+
+    _isExpired(fetchedAt) {
+        if (!fetchedAt) return true;
+        const time = new Date(fetchedAt).getTime();
+        return (Date.now() - time) >= (TTL_DAYS * 24 * 60 * 60 * 1000);
+    }
+
+    _getCacheFilePath() {
+        return path.join(app.getPath('userData'), 'secrets.enc');
+    }
+
+    _readCache() {
+        try {
+            const filePath = this._getCacheFilePath();
+            if (!fs.existsSync(filePath)) return null;
+            const base64 = fs.readFileSync(filePath, 'utf8');
+            const buffer = Buffer.from(base64, 'base64');
+            const decrypted = safeStorage.decryptString(buffer);
+            return JSON.parse(decrypted);
+        } catch (err) {
+            this.logger.logEvent({ message: 'cache read failed', reason: err.message });
+            return null;
+        }
+    }
+
+    _writeCache(data) {
+        try {
+            const cacheData = { ...data, fetchedAt: new Date().toISOString() };
+            const encrypted = safeStorage.encryptString(JSON.stringify(cacheData));
+            fs.writeFileSync(this._getCacheFilePath(), encrypted.toString('base64'), 'utf8');
+        } catch (err) {
+            this.logger.logEvent({ message: 'cache write failed', reason: err.message });
+        }
+    }
+
+    async _fetchWithTimeout(url, options = {}, timeoutMs = 5000) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const response = await fetch(url, { ...options, signal: controller.signal });
+            let data = null;
+            try { data = await response.json(); } catch {}
+            return { ok: response.ok, status: response.status, data };
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+
+    _getDevSecretsPath() {
+        return path.join(__dirname, '../../secrets.json');
+    }
+
+    _logDevSecretsSource() {
+        const secretsPath = this._getDevSecretsPath();
+        try {
+            if (fs.existsSync(secretsPath)) {
+                const secrets = JSON.parse(fs.readFileSync(secretsPath, 'utf8'));
+                this.logger.logEvent({ message: 'dev secrets', source: 'secrets.json', availableKeys: Object.keys(secrets) });
+            } else {
+                this.logger.logEvent({ message: 'dev secrets', source: 'env vars only', note: 'secrets.json not found at ' + secretsPath });
+            }
+        } catch (err) {
+            this.logger.logEvent({ message: 'dev secrets', source: 'none', error: err.message });
+        }
+    }
+
+    _getDevSecret(key) {
+        if (process.env[key]) return process.env[key];
+        try {
+            const secretsPath = this._getDevSecretsPath();
+            if (fs.existsSync(secretsPath)) {
+                const secrets = JSON.parse(fs.readFileSync(secretsPath, 'utf8'));
+                return secrets[key] ?? null;
+            }
+        } catch {}
+        return null;
+    }
+
+    register(_props) {
+        ipcHandleSync('secrets-getSecret', (key) => SecretsFeature.getInstance().getSecret(key), ipcMain);
+        ipcHandleSync('secrets-getStatus', () => SecretsFeature.getInstance().getStatus(), ipcMain);
+    }
+
+    registerRenderer(spec, ipcRenderer) {
+        spec.secrets = {};
+        spec.secrets.getSecret = ipcCallSync('secrets-getSecret', ipcRenderer);
+        spec.secrets.getStatus = ipcCallSync('secrets-getStatus', ipcRenderer);
+        spec.registerFeatures(['secrets']);
+    }
+}
+
+module.exports = SecretsFeature;

--- a/src/modules/secrets.js
+++ b/src/modules/secrets.js
@@ -1,8 +1,0 @@
-const secrets = require('../secrets.json')
-
-const getSecret = (key) => secrets[key];
-
-
-module.exports =  {
-    getSecret
-}


### PR DESCRIPTION
## Summary

- Replaces the bundled plaintext `src/secrets.json` with runtime secret provisioning via the Incyclist backend, stored locally using Electron `safeStorage` (OS-level encryption)
- A dynamic app-id derived from `sha256(version|os|uuid)` replaces the previous static `APP_ID` that required build-time injection and cross-system sync — no GitHub secret or config value to keep in sync
- Removes all manual secrets setup from CI workflows, build configs, and README

## What changed

**New: `src/features/secrets/SecretsFeature`**
- On startup: checks encrypted local cache → if expired/missing, provisions from `POST /api/v1/secrets/desktop`; if valid, runs a lightweight status check against the server
- Cache stored via `safeStorage.encryptString()` in the user data directory (`secrets.enc`)
- Retries every 60s and on `powerMonitor.resume` until server-confirmed; uses cached secrets optimistically (`status = 'ok'`, `_pendingVerification = true`) when offline or server unreachable
- `getSecret(key)` / `getStatus()` are synchronous IPC calls (matches `ISecretBinding` interface)
- Dev mode (`ENVIRONMENT=dev`): reads from local `src/secrets.json` or env vars, no backend needed

**Removed**
- `src/modules/secrets.js` — deleted
- `AppSettings.getSecret` / `appSettings-getSecret` IPC handler — removed; capability tokens `appSettings.secret` and `appSettings.secret.v2` removed from `registerFeatures()`
- `scripts/inject-app-id.js` and all `injectAppId()` calls in forge configs
- `src/secrets.json` injection step from all three CI workflows (linux, mac, windows)
- `!src/secrets.json` exclusion entries from build configs (file is gitignored, never present in CI)

**Updated**
- `src/features/mq.js`: reads broker/credentials from `SecretsFeature` at connect time instead of at startup
- `src/app.js`: calls `SecretsFeature.init()` in `onReady()` after settings are loaded
- `README.MD`: replaces manual secrets setup instructions with dev/normal run documentation
- `.gitignore`: adds `src/.settings/` (dev-mode runtime directory)

## Test plan

- [ ] `npm test` passes (117 tests)
- [ ] `npm run dev` starts, connects to secrets service, MQTT connects — verify in `~/.config/Incyclist/logs/logfile.json`
- [ ] Delete `~/.config/Incyclist/secrets.enc`, restart — re-provisions cleanly
- [ ] `ENVIRONMENT=dev npm run dev` — reads from local `src/secrets.json`, no backend call

🤖 Generated with [Claude Code](https://claude.com/claude-code)