### PR TITLE
feat: WebBluetooth BLE binding for Linux desktop

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,7 +48,10 @@ class IncyclistApp
             Menu.setApplicationMenu(null);
         }
         if (process.platform==='linux' && !process.env.DEBUG && !process.env.LOADER_DEBUG && this.environment==='prod')  {
-            app.commandLine.appendSwitch('no-sandbox');            
+            app.commandLine.appendSwitch('no-sandbox');
+        }
+        if (process.platform === 'linux') {
+            app.commandLine.appendSwitch('enable-experimental-web-platform-features')
         }
 
 

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -10,6 +10,7 @@ const DownloadManager = require('./download').getInstance();
 const Network = require('./Network').getInstance()
 const MessageQueue = require('./mq').getInstance();
 const Ble = require('./ble').getInstance()
+const WebBle = require('./webble/feature').getInstance()
 const Ant = require('./ant').getInstance();
 const Fs = require('./fs').getInstance();
 const OAuth = require('./oauth').getInstance()
@@ -32,6 +33,7 @@ function initFeaturesApp( props ) {
     Network.register(props);
     MessageQueue.register(props);
     Ble.register(props);
+    WebBle.register(props);
     Ant.register(props);
     SerialFeature.register(props);
     Fs.register(props);
@@ -70,6 +72,7 @@ function initFeaturesWeb( electron,ipcRenderer) {
     Network.registerRenderer(electron,ipcRenderer);
     MessageQueue.registerRenderer(electron,ipcRenderer);
     Ble.registerRenderer(electron,ipcRenderer);
+    WebBle.registerRenderer(electron,ipcRenderer);
     Ant.registerRenderer(electron,ipcRenderer);
     SerialFeature.registerRenderer(electron,ipcRenderer);
     Fs.registerRenderer(electron,ipcRenderer);

--- a/src/features/webble/feature.js
+++ b/src/features/webble/feature.js
@@ -1,0 +1,297 @@
+const { app, ipcMain } = require('electron')
+const { ipcHandleNoResponse, ipcHandleSync, ipcCallSync } = require('../utils')
+const Feature = require('../base')
+const WebBleIpcBinding = require('./ipc-binding')
+const { EventLogger } = require('gd-eventlog')
+
+const CONNECT_TARGET_TIMEOUT = 30 * 1000
+
+class WebBleFeature extends Feature {
+    static _instance
+
+    constructor() {
+        super()
+        this.logger = new EventLogger('WebBLE')
+
+        // Scanning and connecting are independent: a connect request must never
+        // stop the request loop, otherwise no further devices get discovered.
+        this.scanning = false
+        this.connectTargetId = null          // MAC of the device a connect is waiting for
+        this.connectTargetExpires = 0
+
+        this.pendingCallback = null          // parked select-bluetooth-device callback
+        this.lastDeviceList = []             // device list of the most recent event
+        this.discoveredDeviceIds = new Set() // MACs approved in the current scan
+
+        // deviceName → Set<MAC>. Device names are NOT unique (e.g. two "Zwift Click"
+        // controllers), so a name can map to several MACs.
+        this.deviceMacsByName = new Map()
+
+        // The approval the renderer has not consumed yet. Exactly one device is
+        // approved per requestDevice call, so this maps 1:1 to the device object
+        // that requestDevice resolves with — consumed via takeApproved().
+        this.lastApproved = null             // { deviceId, deviceName }
+
+        this._scanLoopTimeout = null
+        this._iterationInFlight = false
+        this._lastLoggedDeviceIds = null
+    }
+
+    static getInstance() {
+        if (!WebBleFeature._instance)
+            WebBleFeature._instance = new WebBleFeature()
+        return WebBleFeature._instance
+    }
+
+    getBinding() {
+        return WebBleIpcBinding.getInstance()
+    }
+
+    _hasConnectTarget() {
+        if (this.connectTargetId && Date.now() > this.connectTargetExpires) {
+            this.logger.logEvent({ message: 'connect target expired', deviceId: this.connectTargetId })
+            this.connectTargetId = null
+        }
+        return !!this.connectTargetId
+    }
+
+    _shouldLoop() {
+        return this.scanning || this._hasConnectTarget()
+    }
+
+    _approve(device, callback) {
+        this.discoveredDeviceIds.add(device.deviceId)
+        if (device.deviceName) {
+            const macs = this.deviceMacsByName.get(device.deviceName) ?? new Set()
+            macs.add(device.deviceId)
+            this.deviceMacsByName.set(device.deviceName, macs)
+        }
+        this.lastApproved = { deviceId: device.deviceId, deviceName: device.deviceName ?? null }
+        this.pendingCallback = null
+        this.logger.logEvent({ message: 'approving device', deviceId: device.deviceId, deviceName: device.deviceName })
+        callback(device.deviceId)
+    }
+
+    /**
+     * Chromium substitutes "Unknown or Unsupported Device (<MAC>)" for devices
+     * that do not advertise a name. Fitness devices always advertise a name, so
+     * nameless devices are never approved.
+     */
+    _isUsableName(name) {
+        return !!name && !name.startsWith('Unknown or Unsupported Device')
+    }
+
+    _onSelectBluetoothDevice(event, deviceList, callback) {
+        event.preventDefault()
+        this.lastDeviceList = deviceList
+
+        // the chooser re-fires on every advertisement update — only log real changes
+        const idsKey = deviceList.map(d => d.deviceId).sort().join('|')
+        if (idsKey !== this._lastLoggedDeviceIds) {
+            this._lastLoggedDeviceIds = idsKey
+            this.logger.logEvent({
+                message: 'select-bluetooth-device',
+                scanning: this.scanning,
+                connectTarget: this.connectTargetId,
+                devices: deviceList.length,
+                ids: deviceList.map(d => d.deviceId),
+            })
+        }
+
+        // A pending connect request always takes priority — approve its target even
+        // if it was already discovered during this scan.
+        if (this._hasConnectTarget()) {
+            const target = deviceList.find(d => d.deviceId === this.connectTargetId)
+            if (target) {
+                this.connectTargetId = null
+                this._approve(target, callback)
+                return
+            }
+        }
+
+        if (this.scanning) {
+            // Only named devices get approved. When nothing usable is new, the
+            // callback is parked below — the event re-fires on device list changes.
+            const newDevice = deviceList.find(d =>
+                !this.discoveredDeviceIds.has(d.deviceId) && this._isUsableName(d.deviceName))
+            if (newDevice) {
+                this._approve(newDevice, callback)
+                return
+            }
+        }
+
+        if (this._shouldLoop()) {
+            // Nothing to approve right now — park the request. The event fires again
+            // as soon as the device list changes.
+            this.pendingCallback = callback
+        } else {
+            // idle: cancel the request so no chooser is left dangling
+            callback('')
+        }
+    }
+
+    startScan(serviceUUIDs, allowDuplicates) {
+        this.logger.logEvent({ message: 'startScan', serviceUUIDs, allowDuplicates })
+        this.scanning = true
+        this.pendingCallback = null
+        this.discoveredDeviceIds = new Set()
+        this._lastLoggedDeviceIds = null
+        this._triggerScanIteration()
+    }
+
+    stopScan() {
+        this.logger.logEvent({ message: 'stopScan', hadPendingCallback: !!this.pendingCallback })
+        this.scanning = false
+
+        // keep the loop alive while a connect request is still waiting for its device
+        if (this._shouldLoop()) return
+
+        if (this._scanLoopTimeout) {
+            clearTimeout(this._scanLoopTimeout)
+            this._scanLoopTimeout = null
+        }
+        if (this.pendingCallback) {
+            const cb = this.pendingCallback
+            this.pendingCallback = null
+            cb('')
+        }
+    }
+
+    connect(deviceId) {
+        this.logger.logEvent({ message: 'connect', deviceId })
+        this.connectTargetId = deviceId
+        this.connectTargetExpires = Date.now() + CONNECT_TARGET_TIMEOUT
+
+        // A parked chooser only re-fires when its device list changes — if the target
+        // is already in the last list, approve it right away.
+        if (this.pendingCallback) {
+            const target = this.lastDeviceList.find(d => d.deviceId === deviceId)
+            if (target) {
+                const cb = this.pendingCallback
+                this.connectTargetId = null
+                this._approve(target, cb)
+                return
+            }
+        }
+
+        // make sure the request loop is running (it may be idle when not scanning)
+        if (!this._iterationInFlight && !this._scanLoopTimeout)
+            this._triggerScanIteration()
+    }
+
+    disconnect(_deviceId) {
+        // WebBluetooth GATT disconnect is handled in renderer directly
+    }
+
+    /**
+     * Consume the approval that has not been picked up yet. Called (via sync IPC)
+     * by the renderer right after requestDevice resolves. The device name must
+     * match as a sanity check; the MAC is returned exactly once.
+     */
+    takeApproved(deviceName) {
+        const approved = this.lastApproved
+        if (!approved) return null
+        if ((approved.deviceName ?? null) !== (deviceName ?? null)) return null
+        this.lastApproved = null
+        return approved.deviceId
+    }
+
+    /**
+     * Best-effort name → MAC lookup. Names are not unique, so this only answers
+     * when exactly one MAC is known for the name — otherwise null.
+     */
+    getMac(deviceName) {
+        const macs = this.deviceMacsByName.get(deviceName)
+        if (macs?.size === 1) return macs.values().next().value
+        return null
+    }
+
+    _triggerScanIteration() {
+        if (this._iterationInFlight) return
+        if (!this._shouldLoop()) return
+        const mainWindow = app.incyclistApp?.getMainWindow()
+        const webContents = mainWindow?.win?.webContents
+        if (!webContents || webContents.isDestroyed?.()) return
+
+        const script = `(async function() {
+            if (!window._webBleBinding) return
+            try {
+                const device = await navigator.bluetooth.requestDevice({
+                    acceptAllDevices: true,
+                    optionalServices: window._webBleBinding._optionalServices
+                })
+                if (device) await window._webBleBinding._processDiscoveredDevice(device, true)
+            } catch(e) {}
+        })()`
+
+        this._iterationInFlight = true
+        this._scanLoopTimeout = null
+        webContents.executeJavaScript(script, true)
+            .then(() => this._onIterationDone(500))
+            .catch(() => this._onIterationDone(2000))
+    }
+
+    _onIterationDone(delay) {
+        this._iterationInFlight = false
+        if (this._shouldLoop())
+            this._scanLoopTimeout = setTimeout(() => this._triggerScanIteration(), delay)
+        else
+            this._scanLoopTimeout = null
+    }
+
+    register(_props) {
+        if (process.platform !== 'linux') {
+            return;
+        }
+        this.logger.logEvent({ message: 'register' })
+
+
+        app.on('web-contents-created', (_event, contents) => {
+            contents.on('select-bluetooth-device', this._onSelectBluetoothDevice.bind(this))
+        })
+
+        ipcHandleNoResponse('webble-start-scan', this.startScan.bind(this), ipcMain)
+        ipcHandleNoResponse('webble-stop-scan', this.stopScan.bind(this), ipcMain)
+        ipcHandleNoResponse('webble-connect', this.connect.bind(this), ipcMain)
+        ipcHandleNoResponse('webble-disconnect', this.disconnect.bind(this), ipcMain)
+        ipcHandleSync('webble-get-mac', this.getMac.bind(this), ipcMain)
+        ipcHandleSync('webble-take-approved', this.takeApproved.bind(this), ipcMain)
+    }
+
+    registerRenderer(spec, ipcRenderer) {
+        if (process.platform !== 'linux') {
+            return;
+        }
+
+        spec.webble = {}
+
+        WebBleIpcBinding.getInstance().setApi(spec.webble)
+
+        spec.webble.getInstance = () => WebBleFeature.getInstance().getBinding()
+
+        spec.webble.startScanning = (serviceUUIDs, allowDuplicates) => {
+            ipcRenderer.send('webble-start-scan', serviceUUIDs, allowDuplicates)
+        }
+
+        spec.webble.stopScanning = () => {
+            ipcRenderer.send('webble-stop-scan')
+        }
+
+        spec.webble.connect = (deviceId) => {
+            ipcRenderer.send('webble-connect', deviceId)
+        }
+
+        spec.webble.disconnect = (deviceId) => {
+            ipcRenderer.send('webble-disconnect', deviceId)
+        }
+
+        spec.webble.getMac = ipcCallSync('webble-get-mac', ipcRenderer)
+        spec.webble.takeApproved = ipcCallSync('webble-take-approved', ipcRenderer)
+
+        // 'webble-services': binding supports setSupportedServices() (devices lib
+        // announces its BLE service list — no desktop release needed for new services)
+        spec.registerFeatures(['webble', 'webble-services'])
+    }
+}
+
+module.exports = WebBleFeature

--- a/src/features/webble/feature.test.js
+++ b/src/features/webble/feature.test.js
@@ -1,0 +1,618 @@
+jest.mock('electron', () => ({
+    app: {
+        on: jest.fn(),
+        incyclistApp: { getMainWindow: () => ({ win: { webContents: { send: jest.fn() } } }) },
+    },
+    ipcMain: { on: jest.fn() },
+}))
+
+jest.mock('../utils', () => ({
+    ipcHandleNoResponse: jest.fn(),
+    ipcHandleSync: jest.fn(),
+    ipcCallSync: jest.fn(() => jest.fn()),
+    ipcSendEvent: jest.fn(),
+}))
+
+jest.mock('./ipc-binding', () => {
+    const setApi = jest.fn()
+    return { getInstance: jest.fn(() => ({ setApi })) }
+})
+
+const { app } = require('electron')
+const { ipcHandleNoResponse, ipcHandleSync, ipcCallSync, ipcSendEvent } = require('../utils')
+const WebBleFeature = require('./feature')
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    WebBleFeature._instance = undefined
+})
+
+// ── initial state ─────────────────────────────────────────────────────────────
+
+describe('WebBleFeature — initial state', () => {
+
+    test('scanning starts false', () => {
+        expect(new WebBleFeature().scanning).toBe(false)
+    })
+
+    test('connectTargetId starts null', () => {
+        expect(new WebBleFeature().connectTargetId).toBeNull()
+    })
+
+    test('pendingCallback starts null', () => {
+        expect(new WebBleFeature().pendingCallback).toBeNull()
+    })
+
+    test('lastApproved starts null', () => {
+        expect(new WebBleFeature().lastApproved).toBeNull()
+    })
+
+})
+
+// ── startScan / stopScan ─────────────────────────────────────────────────────
+
+describe('WebBleFeature — startScan / stopScan', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+        jest.spyOn(feature, '_triggerScanIteration').mockImplementation(() => {})
+    })
+
+    test('startScan sets scanning to true and resets accumulated state', () => {
+        feature.scanning = false
+        feature.pendingCallback = jest.fn()
+        feature.discoveredDeviceIds = new Set(['old-id'])
+
+        feature.startScan()
+
+        expect(feature.scanning).toBe(true)
+        expect(feature.pendingCallback).toBeNull()
+        expect(feature.discoveredDeviceIds.size).toBe(0)
+    })
+
+    test('startScan calls _triggerScanIteration', () => {
+        feature.startScan()
+        expect(feature._triggerScanIteration).toHaveBeenCalled()
+    })
+
+    test('stopScan sets scanning to false', () => {
+        feature.scanning = true
+        feature.stopScan()
+        expect(feature.scanning).toBe(false)
+    })
+
+    test('stopScan calls pendingCallback with empty string when no connect target', () => {
+        const cb = jest.fn()
+        feature.scanning = true
+        feature.pendingCallback = cb
+
+        feature.stopScan()
+
+        expect(cb).toHaveBeenCalledWith('')
+        expect(feature.pendingCallback).toBeNull()
+    })
+
+    test('stopScan is safe when pendingCallback is null', () => {
+        feature.scanning = true
+        feature.pendingCallback = null
+        expect(() => feature.stopScan()).not.toThrow()
+    })
+
+    test('stopScan clears pending scan loop timeout when no connect target', () => {
+        feature.scanning = true
+        feature._scanLoopTimeout = setTimeout(() => {}, 60000)
+        feature.stopScan()
+        expect(feature._scanLoopTimeout).toBeNull()
+    })
+
+    test('stopScan keeps loop alive when a connect target is still pending', () => {
+        feature.scanning = true
+        feature.connectTargetId = 'D4:C9:BB:7D:CB:AF'
+        feature.connectTargetExpires = Date.now() + 30000
+        feature._scanLoopTimeout = null
+
+        feature.stopScan()
+
+        // scanning is false but connectTarget is active → _shouldLoop() is still true
+        expect(feature.scanning).toBe(false)
+        // pendingCallback should NOT be called (loop still needs it)
+        const cb = jest.fn()
+        feature.pendingCallback = cb
+        feature.stopScan()
+        // still has a connect target, so callback is not flushed
+        expect(cb).not.toHaveBeenCalled()
+    })
+
+})
+
+// ── connect ───────────────────────────────────────────────────────────────────
+
+describe('WebBleFeature — connect', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+        jest.spyOn(feature, '_triggerScanIteration').mockImplementation(() => {})
+        jest.spyOn(feature, '_approve').mockImplementation((device, cb) => cb(device.deviceId))
+    })
+
+    test('sets connectTargetId', () => {
+        feature.connect('D4:C9:BB:7D:CB:AF')
+        expect(feature.connectTargetId).toBe('D4:C9:BB:7D:CB:AF')
+    })
+
+    test('sets connectTargetExpires in the future', () => {
+        const before = Date.now()
+        feature.connect('D4:C9:BB:7D:CB:AF')
+        expect(feature.connectTargetExpires).toBeGreaterThan(before)
+    })
+
+    test('immediately approves from parked callback when target is already in lastDeviceList', () => {
+        const cb = jest.fn()
+        feature.pendingCallback = cb
+        feature.lastDeviceList = [{ deviceId: 'D4:C9:BB:7D:CB:AF', deviceName: 'Volt' }]
+
+        feature.connect('D4:C9:BB:7D:CB:AF')
+
+        expect(feature._approve).toHaveBeenCalledWith(
+            { deviceId: 'D4:C9:BB:7D:CB:AF', deviceName: 'Volt' },
+            cb
+        )
+    })
+
+    test('starts scan loop when idle and not already running', () => {
+        feature._iterationInFlight = false
+        feature._scanLoopTimeout = null
+
+        feature.connect('D4:C9:BB:7D:CB:AF')
+
+        expect(feature._triggerScanIteration).toHaveBeenCalled()
+    })
+
+})
+
+// ── _triggerScanIteration ─────────────────────────────────────────────────────
+
+describe('WebBleFeature — _triggerScanIteration', () => {
+
+    let feature, webContents
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+        feature.scanning = true
+        webContents = {
+            executeJavaScript: jest.fn(() => Promise.resolve()),
+        }
+        app.incyclistApp = { getMainWindow: () => ({ win: { webContents } }) }
+    })
+
+    afterEach(async () => {
+        // stop the self-rescheduling loop: _onIterationDone may still be pending
+        // as a microtask and would otherwise re-arm the timer forever
+        feature.scanning = false
+        feature.connectTargetId = null
+        await new Promise(r => setImmediate(r))
+        if (feature._scanLoopTimeout) clearTimeout(feature._scanLoopTimeout)
+    })
+
+    test('calls executeJavaScript with userGesture=true when scanning', () => {
+        feature._triggerScanIteration()
+        expect(webContents.executeJavaScript).toHaveBeenCalledWith(
+            expect.stringContaining('requestDevice'),
+            true
+        )
+    })
+
+    test('skips executeJavaScript when not scanning and no connect target', () => {
+        feature.scanning = false
+        feature._triggerScanIteration()
+        expect(webContents.executeJavaScript).not.toHaveBeenCalled()
+    })
+
+    test('skips executeJavaScript when no main window available', () => {
+        app.incyclistApp = null
+        feature._triggerScanIteration()
+        expect(webContents.executeJavaScript).not.toHaveBeenCalled()
+    })
+
+    test('skips when _iterationInFlight is already true', () => {
+        feature._iterationInFlight = true
+        feature._triggerScanIteration()
+        expect(webContents.executeJavaScript).not.toHaveBeenCalled()
+    })
+
+    test('sets _scanLoopTimeout after scan completes while still scanning', async () => {
+        feature._triggerScanIteration()
+        await new Promise(r => setImmediate(r))
+        expect(feature._scanLoopTimeout).not.toBeNull()
+        clearTimeout(feature._scanLoopTimeout)
+    })
+
+    test('does not set _scanLoopTimeout when scanning stops and no connect target', async () => {
+        let resolveJs
+        webContents.executeJavaScript.mockReturnValue(new Promise(r => { resolveJs = r }))
+        feature._triggerScanIteration()
+        feature.scanning = false
+        resolveJs()
+        await new Promise(r => setImmediate(r))
+        expect(feature._scanLoopTimeout).toBeNull()
+    })
+
+    test('script references window._webBleBinding and _processDiscoveredDevice', () => {
+        feature._triggerScanIteration()
+        const [script] = webContents.executeJavaScript.mock.calls[0]
+        expect(script).toContain('window._webBleBinding')
+        expect(script).toContain('_processDiscoveredDevice')
+    })
+
+    test('script passes approved=true to _processDiscoveredDevice', () => {
+        feature._triggerScanIteration()
+        const [script] = webContents.executeJavaScript.mock.calls[0]
+        expect(script).toContain('_processDiscoveredDevice(device, true)')
+    })
+
+})
+
+// ── _onSelectBluetoothDevice ──────────────────────────────────────────────────
+
+describe('WebBleFeature — _onSelectBluetoothDevice', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+    })
+
+    const makeEvent = () => ({ preventDefault: jest.fn() })
+    const makeDeviceList = (...ids) =>
+        ids.map(id => ({ deviceId: id, deviceName: `Device ${id}` }))
+
+    test('scanning: calls preventDefault', () => {
+        feature.scanning = true
+        const event = makeEvent()
+        feature._onSelectBluetoothDevice(event, makeDeviceList('aa'), jest.fn())
+        expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    test('scanning: approves first new named device', () => {
+        feature.scanning = true
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa', 'bb'), cb)
+        expect(cb).toHaveBeenCalledWith('aa')
+    })
+
+    test('scanning: prefers named device over anonymous', () => {
+        feature.scanning = true
+        const cb = jest.fn()
+        const deviceList = [
+            { deviceId: 'anon-1', deviceName: null },
+            { deviceId: 'kickr-1', deviceName: 'KICKR CORE' },
+        ]
+        feature._onSelectBluetoothDevice(makeEvent(), deviceList, cb)
+        expect(cb).toHaveBeenCalledWith('kickr-1')
+    })
+
+    test('scanning: parks callback when only anonymous devices remain', () => {
+        feature.scanning = true
+        const cb = jest.fn()
+        const deviceList = [
+            { deviceId: 'anon-1', deviceName: null },
+            { deviceId: 'anon-2', deviceName: null },
+        ]
+        feature._onSelectBluetoothDevice(makeEvent(), deviceList, cb)
+        expect(cb).not.toHaveBeenCalled()
+        expect(feature.pendingCallback).toBe(cb)
+    })
+
+    test('scanning: never approves Chromium "Unknown or Unsupported Device" placeholders', () => {
+        feature.scanning = true
+        const cb = jest.fn()
+        const deviceList = [
+            { deviceId: '52:7F:3B:3C:DE:AB', deviceName: 'Unknown or Unsupported Device (52:7F:3B:3C:DE:AB)' },
+        ]
+        feature._onSelectBluetoothDevice(makeEvent(), deviceList, cb)
+        expect(cb).not.toHaveBeenCalled()
+        expect(feature.pendingCallback).toBe(cb)
+        expect(feature.deviceMacsByName.size).toBe(0)
+    })
+
+    test('logs select-bluetooth-device only when the device list changes', () => {
+        feature.scanning = true
+        feature.logger.logEvent = jest.fn()
+        feature.discoveredDeviceIds = new Set(['aa', 'bb'])   // nothing to approve → parked
+
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), jest.fn())
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), jest.fn())
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa', 'bb'), jest.fn())
+
+        const selectLogs = feature.logger.logEvent.mock.calls
+            .filter(c => c[0].message === 'select-bluetooth-device')
+        expect(selectLogs).toHaveLength(2)
+    })
+
+    test('scanning: parks callback when all devices already seen', () => {
+        feature.scanning = true
+        feature.discoveredDeviceIds = new Set(['aa', 'bb'])
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa', 'bb'), cb)
+        expect(cb).not.toHaveBeenCalled()
+        expect(feature.pendingCallback).toBe(cb)
+    })
+
+    test('scanning: deduplicates — same device not approved twice', () => {
+        feature.scanning = true
+        const cb1 = jest.fn()
+        const cb2 = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), cb1)
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), cb2)
+        expect(cb1).toHaveBeenCalledWith('aa')
+        expect(cb2).not.toHaveBeenCalled()
+        expect(feature.pendingCallback).toBe(cb2)
+    })
+
+    test('scanning: approves second new device on subsequent event', () => {
+        feature.scanning = true
+        const cb1 = jest.fn()
+        const cb2 = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), cb1)
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa', 'bb'), cb2)
+        expect(cb1).toHaveBeenCalledWith('aa')
+        expect(cb2).toHaveBeenCalledWith('bb')
+    })
+
+    test('scanning: stores MAC in deviceMacsByName as a Set', () => {
+        feature.scanning = true
+        feature._onSelectBluetoothDevice(makeEvent(), [
+            { deviceId: 'F8:E1:A4:32:9C:09', deviceName: 'KICKR CORE C378' },
+        ], jest.fn())
+        const macs = feature.deviceMacsByName.get('KICKR CORE C378')
+        expect(macs).toBeInstanceOf(Set)
+        expect(macs.has('F8:E1:A4:32:9C:09')).toBe(true)
+    })
+
+    test('scanning: two devices with the same name both get their MACs stored', () => {
+        feature.scanning = true
+        feature._onSelectBluetoothDevice(makeEvent(), [
+            { deviceId: 'AA:BB:CC:DD:EE:01', deviceName: 'Zwift Click' },
+        ], jest.fn())
+        feature._onSelectBluetoothDevice(makeEvent(), [
+            { deviceId: 'AA:BB:CC:DD:EE:02', deviceName: 'Zwift Click' },
+        ], jest.fn())
+        const macs = feature.deviceMacsByName.get('Zwift Click')
+        expect(macs.size).toBe(2)
+        expect(macs.has('AA:BB:CC:DD:EE:01')).toBe(true)
+        expect(macs.has('AA:BB:CC:DD:EE:02')).toBe(true)
+    })
+
+    test('scanning: does not store MAC for anonymous device', () => {
+        feature.scanning = true
+        feature._onSelectBluetoothDevice(makeEvent(), [
+            { deviceId: 'anon-1', deviceName: null },
+        ], jest.fn())
+        expect(feature.deviceMacsByName.size).toBe(0)
+    })
+
+    test('scanning: sets lastApproved to the approved device', () => {
+        feature.scanning = true
+        feature._onSelectBluetoothDevice(makeEvent(), [
+            { deviceId: 'F8:E1:A4:32:9C:09', deviceName: 'KICKR CORE' },
+        ], jest.fn())
+        expect(feature.lastApproved).toEqual({ deviceId: 'F8:E1:A4:32:9C:09', deviceName: 'KICKR CORE' })
+    })
+
+    test('connect target: auto-approves target when found in list', () => {
+        feature.connectTargetId = 'target-mac'
+        feature.connectTargetExpires = Date.now() + 30000
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('other', 'target-mac'), cb)
+        expect(cb).toHaveBeenCalledWith('target-mac')
+        expect(feature.connectTargetId).toBeNull()
+    })
+
+    test('connect target: takes priority over scan when both active', () => {
+        feature.scanning = true
+        feature.connectTargetId = 'target-mac'
+        feature.connectTargetExpires = Date.now() + 30000
+        const cb = jest.fn()
+        feature.discoveredDeviceIds = new Set()
+        // List contains both a new named scan device and the connect target
+        const deviceList = [
+            { deviceId: 'new-device', deviceName: 'SomeDevice' },
+            { deviceId: 'target-mac', deviceName: 'Volt' },
+        ]
+        feature._onSelectBluetoothDevice(makeEvent(), deviceList, cb)
+        // Should approve the connect target, not the scan device
+        expect(cb).toHaveBeenCalledWith('target-mac')
+        expect(feature.connectTargetId).toBeNull()
+    })
+
+    test('connect target: parks callback when target not in list', () => {
+        feature.connectTargetId = 'target-mac'
+        feature.connectTargetExpires = Date.now() + 30000
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('other-device'), cb)
+        expect(cb).not.toHaveBeenCalled()
+        expect(feature.pendingCallback).toBe(cb)
+    })
+
+    test('idle: cancels the chooser with empty string', () => {
+        feature.scanning = false
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), cb)
+        expect(cb).toHaveBeenCalledWith('')
+    })
+
+    test('idle: does not call ipcSendEvent', () => {
+        feature.scanning = false
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), jest.fn())
+        expect(ipcSendEvent).not.toHaveBeenCalled()
+    })
+
+})
+
+// ── takeApproved ──────────────────────────────────────────────────────────────
+
+describe('WebBleFeature — takeApproved', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+    })
+
+    test('returns MAC when device name matches', () => {
+        feature.lastApproved = { deviceId: 'F8:E1:A4:32:9C:09', deviceName: 'KICKR CORE' }
+        expect(feature.takeApproved('KICKR CORE')).toBe('F8:E1:A4:32:9C:09')
+    })
+
+    test('consume-once: returns null on second call', () => {
+        feature.lastApproved = { deviceId: 'F8:E1:A4:32:9C:09', deviceName: 'KICKR CORE' }
+        feature.takeApproved('KICKR CORE')
+        expect(feature.takeApproved('KICKR CORE')).toBeNull()
+    })
+
+    test('returns null when name does not match', () => {
+        feature.lastApproved = { deviceId: 'F8:E1:A4:32:9C:09', deviceName: 'KICKR CORE' }
+        expect(feature.takeApproved('Volt')).toBeNull()
+    })
+
+    test('returns null when no device has been approved', () => {
+        expect(feature.takeApproved('Volt')).toBeNull()
+    })
+
+    test('handles null name for anonymous device', () => {
+        feature.lastApproved = { deviceId: 'anon-id', deviceName: null }
+        expect(feature.takeApproved(null)).toBe('anon-id')
+    })
+
+    test('returns null when lastApproved name is null but argument is a string', () => {
+        feature.lastApproved = { deviceId: 'anon-id', deviceName: null }
+        expect(feature.takeApproved('SomeName')).toBeNull()
+    })
+
+})
+
+// ── getMac ────────────────────────────────────────────────────────────────────
+
+describe('WebBleFeature — getMac', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+    })
+
+    test('returns MAC when exactly one MAC is known for the name', () => {
+        feature.deviceMacsByName.set('Volt', new Set(['D4:C9:BB:7D:CB:AF']))
+        expect(feature.getMac('Volt')).toBe('D4:C9:BB:7D:CB:AF')
+    })
+
+    test('returns null when multiple MACs are known for the name (duplicate device names)', () => {
+        feature.deviceMacsByName.set('Zwift Click', new Set(['AA:BB:CC:DD:EE:01', 'AA:BB:CC:DD:EE:02']))
+        expect(feature.getMac('Zwift Click')).toBeNull()
+    })
+
+    test('returns null for unknown device name', () => {
+        expect(feature.getMac('Unknown Device')).toBeNull()
+    })
+
+    test('returns null when called with undefined', () => {
+        expect(feature.getMac(undefined)).toBeNull()
+    })
+
+})
+
+// ── register / registerRenderer ───────────────────────────────────────────────
+
+describe('WebBleFeature — register', () => {
+
+    test('registers web-contents-created listener on app', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.register({})
+        expect(app.on).toHaveBeenCalledWith('web-contents-created', expect.any(Function))
+    })
+
+    test('registers all four no-response IPC handlers', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.register({})
+        const keys = ipcHandleNoResponse.mock.calls.map(c => c[0])
+        expect(keys).toContain('webble-start-scan')
+        expect(keys).toContain('webble-stop-scan')
+        expect(keys).toContain('webble-connect')
+        expect(keys).toContain('webble-disconnect')
+    })
+
+    test('registers webble-get-mac and webble-take-approved as sync handlers', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.register({})
+        const syncKeys = ipcHandleSync.mock.calls.map(c => c[0])
+        expect(syncKeys).toContain('webble-get-mac')
+        expect(syncKeys).toContain('webble-take-approved')
+    })
+
+})
+
+describe('WebBleFeature — registerRenderer', () => {
+
+    let spec, ipcRenderer
+
+    beforeEach(() => {
+        spec = { registerFeatures: jest.fn() }
+        ipcRenderer = {
+            send: jest.fn(),
+            on: jest.fn(),
+            removeAllListeners: jest.fn(),
+        }
+    })
+
+    test('populates spec.webble with all required methods', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.registerRenderer(spec, ipcRenderer)
+        expect(typeof spec.webble.getInstance).toBe('function')
+        expect(typeof spec.webble.startScanning).toBe('function')
+        expect(typeof spec.webble.stopScanning).toBe('function')
+        expect(typeof spec.webble.connect).toBe('function')
+        expect(typeof spec.webble.disconnect).toBe('function')
+        expect(typeof spec.webble.getMac).toBe('function')
+        expect(typeof spec.webble.takeApproved).toBe('function')
+    })
+
+    test('wires getMac and takeApproved via ipcCallSync', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.registerRenderer(spec, ipcRenderer)
+        const syncKeys = ipcCallSync.mock.calls.map(c => c[0])
+        expect(syncKeys).toContain('webble-get-mac')
+        expect(syncKeys).toContain('webble-take-approved')
+    })
+
+    test('announces webble capabilities', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.registerRenderer(spec, ipcRenderer)
+        expect(spec.registerFeatures).toHaveBeenCalledWith(['webble', 'webble-services'])
+    })
+
+    test('startScanning sends webble-start-scan IPC', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.registerRenderer(spec, ipcRenderer)
+        spec.webble.startScanning(['1234'], true)
+        expect(ipcRenderer.send).toHaveBeenCalledWith('webble-start-scan', ['1234'], true)
+    })
+
+    test('stopScanning sends webble-stop-scan IPC', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.registerRenderer(spec, ipcRenderer)
+        spec.webble.stopScanning()
+        expect(ipcRenderer.send).toHaveBeenCalledWith('webble-stop-scan')
+    })
+
+    test('connect sends webble-connect IPC with deviceId', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.registerRenderer(spec, ipcRenderer)
+        spec.webble.connect('dev-123')
+        expect(ipcRenderer.send).toHaveBeenCalledWith('webble-connect', 'dev-123')
+    })
+
+})

--- a/src/features/webble/ipc-binding.js
+++ b/src/features/webble/ipc-binding.js
@@ -1,0 +1,722 @@
+const EventEmitter = require('events')
+
+// Default service list — only a FALLBACK for devices-lib versions that do not
+// announce their supported services via setSupportedServices(). The authoritative
+// list is pushed by the devices lib at scan start, so new BLE services do not
+// require a desktop release.
+const FITNESS_SERVICE_UUIDS = [
+    '1826',                                    // FTMS
+    '1818',                                    // Cycling Power (CSP)
+    '1816',                                    // Cycling Speed & Cadence (CSC)
+    '180d',                                    // Heart Rate
+    'a026ee0b-0a7d-4ab3-97fa-f1500f9feb8b',   // Wahoo advanced FTMS
+    '6e40fec1-b5a3-f393-e0a9-e50e24dcca9e',   // Tacx FE-C BLE
+    '00000001-19ca-4651-86e5-fa29dcdd09d1',    // Zwift Play
+    '347b0001',                                // Elite trainer
+]
+
+// WebBluetooth only accepts dashed lowercase 128-bit UUIDs. Callers (the devices
+// layer / Noble conventions) pass any of: 4- or 8-char short forms, 0x-prefixed,
+// dashless 32-char, dashed 36-char — in any case.
+function toFullUUID(uuid) {
+    let u = uuid.toLowerCase()
+    if (u.startsWith('0x')) u = u.slice(2)
+    u = u.replace(/-/g, '')
+    if (u.length === 4) return `0000${u}-0000-1000-8000-00805f9b34fb`
+    if (u.length === 8) return `${u}-0000-1000-8000-00805f9b34fb`
+    if (u.length === 32) return `${u.slice(0, 8)}-${u.slice(8, 12)}-${u.slice(12, 16)}-${u.slice(16, 20)}-${u.slice(20)}`
+    return u
+}
+
+const FITNESS_SERVICE_UUIDS_FULL = FITNESS_SERVICE_UUIDS.map(toFullUUID)
+
+class WebBleIpcBinding extends EventEmitter {
+    static _instance
+
+    constructor() {
+        super()
+        this._state = 'unknown'
+        this._bindings = this
+        this.api = null
+        this.stopRequested = false
+        this._stateEmitted = false
+
+        // Device identity:
+        // - The MAC address (deviceId that main captures from select-bluetooth-device)
+        //   is the ONLY stable, unique identifier — it survives restarts and is what
+        //   gets persisted in settings.json.
+        // - WebBLE opaque device.ids are session-local and can change between approvals.
+        // - Device names are NOT unique (e.g. two "Zwift Click" controllers) and must
+        //   never be used as a cache key or for device lookup.
+        // Each physical device has ONE entry object, keyed in the map under both its
+        // opaque id and (once known) its MAC.
+        this._deviceCache = new Map()      // opaqueId | mac → { device, opaqueId, mac, name, serviceUuids, probed }
+        this._pendingConnects = new Map()  // peripheral id → [{ resolve, timer }]
+
+        // supported services: defaults, replaced/extended via setSupportedServices()
+        this._knownServiceUUIDs = [...FITNESS_SERVICE_UUIDS]
+        this._optionalServices = [...FITNESS_SERVICE_UUIDS_FULL]
+
+        // timeouts / retries (instance fields so tests can shorten them)
+        this._probeTimeoutMs = 10000
+        this._gattConnectTimeoutMs = 10000
+        this._gattConnectRetries = 3
+        this._gattRetryDelayMs = 500
+        this._connectWaitTimeoutMs = 30000
+        this._gattReleaseGraceMs = 15000
+    }
+
+    static getInstance() {
+        if (!WebBleIpcBinding._instance) {
+            WebBleIpcBinding._instance = new WebBleIpcBinding()
+            if (typeof window !== 'undefined')
+                window._webBleBinding = WebBleIpcBinding._instance
+        }
+        return WebBleIpcBinding._instance
+    }
+
+    setApi(api) {
+        this.api = api
+    }
+
+    getApi() {
+        return this.api
+    }
+
+    get state() {
+        return this._state
+    }
+
+    set state(s) {
+        this._state = s
+    }
+
+    pauseLogging() {}
+    resumeLogging() {}
+    setServerDebug(_enabled) {}
+
+    /**
+     * Called by the devices lib (feature-detected, optional in its BleBinding
+     * interface) with the full set of BLE service UUIDs it supports. These become
+     * the optionalServices of every requestDevice call — WebBluetooth denies access
+     * to any service not granted there — and the per-UUID probe fallback list.
+     * Merged with the built-in defaults so an incomplete list can never remove
+     * access; deduped on the full 128-bit form.
+     */
+    setSupportedServices(serviceUUIDs) {
+        if (!Array.isArray(serviceUUIDs) || serviceUUIDs.length === 0) return
+
+        const byFullUUID = new Map()
+        for (const uuid of [...FITNESS_SERVICE_UUIDS, ...serviceUUIDs]) {
+            if (typeof uuid === 'string' && uuid.length > 0)
+                byFullUUID.set(toFullUUID(uuid), uuid)
+        }
+        this._knownServiceUUIDs = [...byFullUUID.values()]
+        this._optionalServices = [...byFullUUID.keys()]
+        console.log('[WebBLE] supported services set:', this._optionalServices.length)
+    }
+
+    on(event, callback) {
+        super.on(event, callback)
+        if (event === 'stateChange' && !this._stateEmitted) {
+            this._stateEmitted = true
+            setTimeout(() => {
+                const available = typeof navigator !== 'undefined' && !!navigator.bluetooth
+                const state = available ? 'poweredOn' : 'poweredOff'
+                this._state = state
+                this.emit('stateChange', state)
+            }, 0)
+        }
+    }
+
+    startScanning(serviceUUIDs, allowDuplicates, callback) {
+        this.stopRequested = false
+        this.getApi().startScanning(serviceUUIDs, allowDuplicates)
+
+        // Fire callback first so the caller can register its 'discover' listener
+        // (devices layer registers via ble.on('discover',...) inside the callback)
+        if (callback) callback(null)
+
+        // Re-emit devices already identified in this session. Only entries with a
+        // known MAC are re-emitted — emitting an opaque id would poison the devices
+        // layer's name-based dedupe and break address matching against settings.json.
+        const seen = new Set()
+        for (const entry of this._deviceCache.values()) {
+            if (seen.has(entry)) continue
+            seen.add(entry)
+            if (!entry.probed || !entry.name || !entry.mac) continue
+            console.log('[WebBLE] startScanning: re-emitting', entry.name, entry.serviceUuids)
+            const peripheral = this._createPeripheral({ id: entry.mac, name: entry.name, serviceUuids: entry.serviceUuids })
+            this.emit('discover', peripheral)
+        }
+
+        // Probe previously-approved devices (getDevices needs no user gesture).
+        // Warms the device-object cache so a later scan-loop approval of the same
+        // physical device can skip the GATT probe.
+        this._discoverApprovedDevices()
+    }
+
+    async _discoverApprovedDevices() {
+        try {
+            const devices = await navigator.bluetooth.getDevices()
+            console.log('[WebBLE] getDevices returned', devices.length, 'device(s)', devices.map(d => d.name))
+            for (const device of devices) {
+                if (this.stopRequested) break
+                const entry = this._deviceCache.get(device.id)
+                if (!entry?.probed) {
+                    await this._processDiscoveredDevice(device, false)
+                }
+            }
+        } catch (err) {
+            console.log('[WebBLE] getDevices failed:', err?.message)
+        }
+    }
+
+    stopScanning(callback) {
+        this.stopRequested = true
+        this.getApi().stopScanning()
+        if (callback) callback()
+    }
+
+    /**
+     * Merge a BluetoothDevice (and optionally its MAC) into the device cache.
+     * The entry is keyed under both the opaque id and the MAC so lookups by either
+     * identifier resolve to the same physical device.
+     */
+    _cacheDevice(device, mac) {
+        let entry = (mac ? this._deviceCache.get(mac) : undefined) ?? this._deviceCache.get(device.id)
+        if (!entry) {
+            entry = { device, opaqueId: device.id, mac: null, name: device.name ?? null, serviceUuids: [], probed: false, inUse: false, releaseTimer: null }
+        }
+        entry.device = device
+        entry.opaqueId = device.id
+        if (device.name) entry.name = device.name
+        if (mac) entry.mac = mac
+
+        this._deviceCache.set(entry.opaqueId, entry)
+        if (entry.mac) this._deviceCache.set(entry.mac, entry)
+        return entry
+    }
+
+    /**
+     * Hand the device object to any _connectPeripheral call waiting for it.
+     * Returns true when at least one waiter was resolved.
+     */
+    _resolvePendingConnects(entry) {
+        let resolved = false
+        for (const key of [entry.mac, entry.opaqueId]) {
+            if (!key) continue
+            const waiters = this._pendingConnects.get(key)
+            if (!waiters) continue
+            this._pendingConnects.delete(key)
+            for (const waiter of waiters) {
+                clearTimeout(waiter.timer)
+                waiter.resolve(entry.device)
+                resolved = true
+            }
+        }
+        return resolved
+    }
+
+    /**
+     * Process a device handed over by the main-process request loop (approved=true)
+     * or found via navigator.bluetooth.getDevices() (approved=false).
+     *
+     * Main approves exactly one device per requestDevice call, so an approved
+     * device maps 1:1 to the approval main just recorded — takeApproved() returns
+     * its MAC. This correlation stays correct even when several physical devices
+     * share the same name.
+     */
+    async _processDiscoveredDevice(device, approved = false) {
+        console.log('[WebBLE] _processDiscoveredDevice', device.name, 'approved:', approved)
+
+        let mac = null
+        if (approved) {
+            mac = this.getApi().takeApproved?.(device.name ?? null) ?? null
+        }
+
+        const entry = this._cacheDevice(device, mac)
+        const hadPendingConnect = this._resolvePendingConnects(entry)
+
+        // Anonymous devices — fitness devices always have names and the adapter drops
+        // nameless peripherals anyway. Skipping GATT here avoids wasting ~1s per device.
+        if (!device.name) {
+            console.log('[WebBLE] skipping anonymous device', device.id)
+            entry.probed = true
+            return
+        }
+
+        // Already probed this physical device (matched via MAC or session id) — the
+        // opaque id may have changed, but the services are known: re-emit from cache.
+        if (entry.probed) {
+            const id = entry.mac ?? entry.opaqueId
+            console.log('[WebBLE] re-emitting known device', entry.name, 'id:', id)
+            const peripheral = this._createPeripheral({ id, name: entry.name, serviceUuids: entry.serviceUuids })
+            this.emit('discover', peripheral)
+            return
+        }
+
+        // A connect request was waiting for exactly this device — the device object
+        // has been handed over; don't delay the connection with a GATT probe.
+        if (hadPendingConnect) return
+
+        const serviceUuids = await this._probeServices(device)
+        if (serviceUuids === null) {
+            // probe failed or timed out — leave probed=false so the next encounter retries
+            return
+        }
+        entry.serviceUuids = serviceUuids
+        entry.probed = true
+
+        // Never emit an opaque id for a device found via getDevices(): the devices
+        // layer dedupes announcements by name, so an opaque-id announcement would
+        // block the later MAC announcement from the scan loop (breaking reconnect
+        // by saved address). The scan loop will re-discover it with its MAC shortly.
+        if (!entry.mac && !approved) {
+            // Release the probe connection: a GATT-connected device stops advertising
+            // and would never show up in the scan loop's chooser to get its MAC.
+            try { device.gatt.disconnect() } catch {}
+            console.log('[WebBLE] deferring emit for', device.name, '— MAC not known yet')
+            return
+        }
+
+        // Keep the probe's GATT connection alive: pairing connects right after the
+        // announcement, and a disconnect→connect cycle within a few seconds yields a
+        // server whose link is already torn down (Chromium/BlueZ race — services and
+        // characteristics then come back empty). Released after a grace period if no
+        // connect request claims it.
+        this._scheduleGattRelease(entry)
+
+        const id = entry.mac ?? entry.opaqueId
+        console.log('[WebBLE] emitting discover for', device.name, 'services:', serviceUuids, 'id:', id)
+        const peripheral = this._createPeripheral({ id, name: device.name, serviceUuids })
+        this.emit('discover', peripheral)
+    }
+
+    /**
+     * Connect to the device's GATT server and read its primary services.
+     * Returns the (possibly empty) list of service UUIDs, or null when the
+     * probe failed or timed out.
+     */
+    async _probeServices(device) {
+        console.log('[WebBLE] connecting to', device.name, 'for service discovery')
+        try {
+            const server = await this._withTimeout(device.gatt.connect(), this._probeTimeoutMs, 'GATT probe connect')
+            console.log('[WebBLE] GATT connected to', device.name)
+
+            const services = await this._withTimeout(this._getServerServices(server), this._probeTimeoutMs, 'service discovery')
+
+            const serviceUuids = services.map(svc => {
+                const shortUuid = this._knownServiceUUIDs.find(u => toFullUUID(u) === svc.uuid.toLowerCase())
+                return shortUuid ?? svc.uuid
+            })
+
+            // deliberately NOT disconnecting here — the caller decides whether the
+            // connection is kept for an imminent connect or released
+            return serviceUuids
+        } catch (err) {
+            console.log('[WebBLE] GATT service discovery failed for', device.name, err?.message)
+            try { device.gatt.disconnect() } catch {}
+            return null
+        }
+    }
+
+    /**
+     * All primary services of a connected GATT server. Some devices (e.g. Wahoo
+     * KICKR) don't support discover-all-primary-services — fall back to probing
+     * each known fitness UUID in parallel.
+     */
+    async _getServerServices(server) {
+        if (!server) return []
+
+        let services = []
+        try {
+            services = await server.getPrimaryServices()
+        } catch {}
+
+        if (!services || services.length === 0) {
+            const results = await Promise.allSettled(
+                this._knownServiceUUIDs.map(async u => server.getPrimaryService(toFullUUID(u)))
+            )
+            services = results.filter(r => r.status === 'fulfilled').map(r => r.value)
+        }
+        return services
+    }
+
+    /**
+     * Release the probe's GATT connection after a grace period unless a connect
+     * request has claimed the device in the meantime.
+     */
+    _scheduleGattRelease(entry) {
+        if (entry.releaseTimer) clearTimeout(entry.releaseTimer)
+        const timer = setTimeout(() => {
+            entry.releaseTimer = null
+            if (entry.inUse) return
+            try {
+                if (entry.device?.gatt?.connected) {
+                    console.log('[WebBLE] releasing unclaimed GATT connection for', entry.name)
+                    entry.device.gatt.disconnect()
+                }
+            } catch {}
+        }, this._gattReleaseGraceMs)
+        timer.unref?.()
+        entry.releaseTimer = timer
+    }
+
+    _claimGattConnection(entry) {
+        if (!entry) return
+        entry.inUse = true
+        if (entry.releaseTimer) {
+            clearTimeout(entry.releaseTimer)
+            entry.releaseTimer = null
+        }
+    }
+
+    _withTimeout(promise, ms, label) {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error(`${label} timeout`)), ms)
+            promise.then(
+                value => { clearTimeout(timer); resolve(value) },
+                err => { clearTimeout(timer); reject(err) }
+            )
+        })
+    }
+
+    _createPeripheral(deviceInfo) {
+        const binding = this
+        const emitter = new EventEmitter()
+
+        const peripheral = {
+            id: deviceInfo.id,
+            uuid: deviceInfo.id,
+            address: deviceInfo.id,
+            name: deviceInfo.name,
+            advertisement: {
+                localName: deviceInfo.name,
+                serviceUuids: deviceInfo.serviceUuids || [],
+            },
+            state: 'disconnected',
+            services: [],
+            _device: null,
+            _server: null,
+            _characteristics: [],
+
+            on:                 (ev, cb)    => emitter.on(ev, cb),
+            off:                (ev, cb)    => emitter.off(ev, cb),
+            once:               (ev, cb)    => emitter.once(ev, cb),
+            removeAllListeners: (ev)        => emitter.removeAllListeners(ev),
+            emit:               (ev, ...a)  => emitter.emit(ev, ...a),
+
+            connectAsync:    () => binding._connectPeripheral(peripheral),
+            disconnect:      (cb) => binding._disconnectPeripheral(peripheral, cb),
+            disconnectAsync: () => new Promise(done => binding._disconnectPeripheral(peripheral, done)),
+
+            discoverServicesAsync:                          (svcs)        => binding._discoverServices(peripheral, svcs),
+            discoverSomeServicesAndCharacteristicsAsync:    (svcs, chars) => binding._discoverServicesAndCharacteristics(peripheral, svcs, chars),
+        }
+
+        return peripheral
+    }
+
+    async _connectPeripheral(peripheral) {
+        // peripheral.id is the MAC whenever it was known at discovery time; the cache
+        // is keyed under both the MAC and the opaque id, so either form resolves here.
+        let device = this._deviceCache.get(peripheral.id)?.device
+        let source = 'cache'
+
+        if (!device) {
+            // Previously granted device from the permission store. Only an exact id
+            // match is trusted — device names are not unique, so matching by name
+            // could connect to the wrong physical device.
+            source = 'getDevices'
+            try {
+                const existingDevices = await navigator.bluetooth.getDevices()
+                device = existingDevices.find(d => d.id === peripheral.id)
+            } catch {}
+        }
+
+        if (!device) {
+            // Ask main to approve this device (by MAC) inside its request loop.
+            // requestDevice must not be called from here: it would race the scan
+            // loop's chooser and needs a user gesture — both reject immediately.
+            // The approved device arrives via _processDiscoveredDevice.
+            source = 'approval'
+            this.getApi().connect(peripheral.id)
+            device = await this._waitForDevice(peripheral.id)
+        }
+
+        console.log('[WebBLE] connectPeripheral', peripheral.name, 'via', source)
+
+        // claim the device: a probe connection kept alive for this device is reused,
+        // and the grace-period release must not tear down an in-use connection
+        const entry = this._cacheDevice(device, peripheral.id !== device.id ? peripheral.id : null)
+        this._claimGattConnection(entry)
+
+        peripheral._device = device
+        device.addEventListener('gattserverdisconnected', () => {
+            peripheral.state = 'disconnected'
+            peripheral.emit('disconnect')
+        }, { once: true })
+
+        peripheral._server = await this._gattConnect(device)
+        peripheral.state = 'connected'
+        console.log('[WebBLE] connectPeripheral done', peripheral.name)
+    }
+
+    _waitForDevice(id) {
+        const cached = this._deviceCache.get(id)
+        if (cached?.device) return Promise.resolve(cached.device)
+
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this._pendingConnects.delete(id)
+                reject(new Error(`device not found: ${id}`))
+            }, this._connectWaitTimeoutMs)
+
+            const waiters = this._pendingConnects.get(id) ?? []
+            waiters.push({ resolve, timer })
+            this._pendingConnects.set(id, waiters)
+        })
+    }
+
+    async _gattConnect(device) {
+        if (device.gatt.connected) return device.gatt
+
+        let lastErr
+        for (let attempt = 1; attempt <= this._gattConnectRetries; attempt++) {
+            try {
+                return await this._withTimeout(device.gatt.connect(), this._gattConnectTimeoutMs, 'GATT connect')
+            } catch (err) {
+                lastErr = err
+                console.log('[WebBLE] GATT connect attempt', attempt, 'failed for', device.name, err?.message)
+                if (attempt < this._gattConnectRetries)
+                    await new Promise(res => setTimeout(res, this._gattRetryDelayMs))
+            }
+        }
+        throw lastErr
+    }
+
+    async _disconnectPeripheral(peripheral, callback) {
+        try {
+            if (peripheral._device?.gatt?.connected) {
+                peripheral._device.gatt.disconnect()
+            }
+        } catch {}
+        const entry = this._deviceCache.get(peripheral.id)
+            ?? (peripheral._device ? this._deviceCache.get(peripheral._device.id) : undefined)
+        if (entry) entry.inUse = false
+        peripheral.state = 'disconnected'
+        if (callback) callback(null)
+    }
+
+    /**
+     * A GATT server can report success on connect() while the underlying link is
+     * already torn down (Chromium/BlueZ disconnect→connect race) — every
+     * getPrimaryService then rejects immediately. When discovery comes back empty
+     * and the server admits it is disconnected, reconnect once and retry.
+     */
+    async _reviveDeadServer(peripheral) {
+        if (!peripheral._device || peripheral._server?.connected) return false
+        console.log('[WebBLE] GATT server dead for', peripheral.name, '— reconnecting')
+        try {
+            peripheral._server = await this._gattConnect(peripheral._device)
+            peripheral.state = 'connected'
+            return true
+        } catch (err) {
+            console.log('[WebBLE] GATT reconnect failed for', peripheral.name, err?.message)
+            return false
+        }
+    }
+
+    /**
+     * Make sure the peripheral has a usable GATT server before discovery. The
+     * devices layer tracks connection state itself and may call discovery without
+     * ever having called connectAsync on THIS peripheral object (its state can be
+     * carried over from an earlier pairing round) — connect on demand using the
+     * device object from the discovery cache.
+     */
+    async _ensureServer(peripheral) {
+        if (peripheral._server && peripheral._server.connected !== false) return true
+
+        if (!peripheral._device) {
+            const entry = this._deviceCache.get(peripheral.id)
+            if (entry?.device) {
+                peripheral._device = entry.device
+                this._claimGattConnection(entry)
+            }
+        }
+        if (!peripheral._device) return false
+
+        try {
+            peripheral._server = await this._gattConnect(peripheral._device)
+            peripheral.state = 'connected'
+            return true
+        } catch (err) {
+            console.log('[WebBLE] on-demand GATT connect failed for', peripheral.name, err?.message)
+            return false
+        }
+    }
+
+    async _discoverServices(peripheral, serviceUUIDs) {
+        if (!await this._ensureServer(peripheral)) return []
+
+        let services = await this._collectServices(peripheral, serviceUUIDs)
+        if (services.length === 0 && await this._reviveDeadServer(peripheral))
+            services = await this._collectServices(peripheral, serviceUUIDs)
+        return services
+    }
+
+    // Noble semantics: an empty uuid list means "discover ALL primary services"
+    async _collectServices(peripheral, serviceUUIDs) {
+        const found = await this._resolveServices(peripheral, serviceUUIDs)
+        return found.map(f => ({ uuid: f.uuid }))
+    }
+
+    /**
+     * Resolve the requested services to live service objects. Empty/absent list →
+     * all primary services. For explicit requests the caller's uuid string is
+     * preserved in the result so the devices layer gets back its own format.
+     */
+    async _resolveServices(peripheral, serviceUUIDs) {
+        const found = []
+        if (!serviceUUIDs || serviceUUIDs.length === 0) {
+            const services = await this._getServerServices(peripheral._server)
+            for (const svc of services) found.push({ uuid: svc.uuid, service: svc })
+        } else {
+            for (const uuid of serviceUUIDs) {
+                try {
+                    const service = await peripheral._server.getPrimaryService(toFullUUID(uuid))
+                    found.push({ uuid, service })
+                } catch {}
+            }
+        }
+        return found
+    }
+
+    async _discoverServicesAndCharacteristics(peripheral, serviceUUIDs, characteristicUUIDs) {
+        if (!await this._ensureServer(peripheral)) return { services: [], characteristics: [] }
+
+        let result = await this._collectServicesAndCharacteristics(peripheral, serviceUUIDs, characteristicUUIDs)
+        if (result.services.length === 0 && await this._reviveDeadServer(peripheral))
+            result = await this._collectServicesAndCharacteristics(peripheral, serviceUUIDs, characteristicUUIDs)
+
+        peripheral._characteristics = result.characteristics
+        return result
+    }
+
+    // Noble semantics: empty serviceUUIDs → all services; empty characteristicUUIDs
+    // → all characteristics of each service
+    async _collectServicesAndCharacteristics(peripheral, serviceUUIDs, characteristicUUIDs) {
+        const found = await this._resolveServices(peripheral, serviceUUIDs)
+        const services = found.map(f => ({ uuid: f.uuid }))
+        const characteristics = []
+
+        const wantAll = !characteristicUUIDs || characteristicUUIDs.length === 0
+        for (const { service } of found) {
+            if (wantAll) {
+                try {
+                    const chars = await service.getCharacteristics()
+                    for (const char of chars) {
+                        characteristics.push(this._createCharacteristic(char, peripheral))
+                    }
+                } catch {}
+            } else {
+                for (const charUUID of characteristicUUIDs) {
+                    try {
+                        const char = await service.getCharacteristic(toFullUUID(charUUID))
+                        characteristics.push(this._createCharacteristic(char, peripheral))
+                    } catch {}
+                }
+            }
+        }
+
+        return { services, characteristics }
+    }
+
+    _createCharacteristic(bleChar, peripheral) {
+        const binding = this
+        const emitter = new EventEmitter()
+
+        const char = {
+            uuid:           bleChar.uuid,
+            _serviceUuid:   bleChar.service?.uuid,
+            _peripheralId:  peripheral.id,
+            properties:     this._extractProperties(bleChar.properties),
+            _bleChar:       bleChar,
+
+            emit:               (ev, ...a)  => emitter.emit(ev, ...a),
+            on:                 (ev, cb)    => emitter.on(ev, cb),
+            off:                (ev, cb)    => emitter.off(ev, cb),
+            once:               (ev, cb)    => emitter.once(ev, cb),
+            removeAllListeners: (ev)        => emitter.removeAllListeners(ev),
+
+            subscribe:   (cb)                      => binding._subscribeCharacteristic(char, cb),
+            unsubscribe: (cb)                      => binding._unsubscribeCharacteristic(char, cb),
+            read:        (cb)                      => binding._readCharacteristic(char, cb),
+            write:       (data, noResp, cb)        => binding._writeCharacteristic(char, data, noResp, cb),
+        }
+
+        return char
+    }
+
+    _extractProperties(bleProps) {
+        if (!bleProps) return []
+        const props = []
+        if (bleProps.broadcast)             props.push('broadcast')
+        if (bleProps.read)                  props.push('read')
+        if (bleProps.writeWithoutResponse)  props.push('writeWithoutResponse')
+        if (bleProps.write)                 props.push('write')
+        if (bleProps.notify)                props.push('notify')
+        if (bleProps.indicate)              props.push('indicate')
+        return props
+    }
+
+    async _subscribeCharacteristic(char, callback) {
+        try {
+            await char._bleChar.startNotifications()
+            char._bleChar.addEventListener('characteristicvaluechanged', (event) => {
+                const value = event.target.value
+                const data = Buffer.from(value.buffer)
+                char.emit('data', data, true)
+            })
+            if (callback) callback(null)
+        } catch (err) {
+            if (callback) callback(err)
+        }
+    }
+
+    async _unsubscribeCharacteristic(char, callback) {
+        try {
+            await char._bleChar.stopNotifications()
+            if (callback) callback(null)
+        } catch (err) {
+            if (callback) callback(err)
+        }
+    }
+
+    async _readCharacteristic(char, callback) {
+        try {
+            const value = await char._bleChar.readValue()
+            const data = Buffer.from(value.buffer)
+            if (callback) callback(null, data)
+        } catch (err) {
+            if (callback) callback(err, null)
+        }
+    }
+
+    async _writeCharacteristic(char, data, withoutResponse, callback) {
+        try {
+            const buf = Buffer.isBuffer(data) ? data : Buffer.from(data)
+            if (withoutResponse) {
+                await char._bleChar.writeValueWithoutResponse(buf)
+            } else {
+                await char._bleChar.writeValueWithResponse(buf)
+            }
+            if (!withoutResponse && callback) callback(null)
+        } catch (err) {
+            if (!withoutResponse && callback) callback(err)
+        }
+    }
+}
+
+module.exports = WebBleIpcBinding

--- a/src/features/webble/ipc-binding.test.js
+++ b/src/features/webble/ipc-binding.test.js
@@ -1,0 +1,1245 @@
+/**
+ * Tests for WebBleIpcBinding (renderer-side Noble-compatible binding).
+ *
+ * navigator.bluetooth is mocked at the global level.
+ * requestDevice scanning is driven by feature.js (main process) via
+ * executeJavaScript — ipc-binding never calls requestDevice itself.
+ *
+ * Identity model under test:
+ * - MAC address (from select-bluetooth-device, via takeApproved) is the primary id
+ * - WebBLE opaque device.ids are session-local aliases
+ * - device names are NOT unique and are never used for lookup
+ */
+
+let WebBleIpcBinding
+
+// requestDevice that never settles — the binding must never call it
+const neverSettle = jest.fn(() => new Promise(() => {}))
+
+const makeBluetooth = (overrides = {}) => ({
+    requestDevice: neverSettle,
+    getDevices: jest.fn().mockResolvedValue([]),
+    getAvailability: jest.fn().mockResolvedValue(true),
+    ...overrides,
+})
+
+const expandUUID = uuid => {
+    if (uuid.length === 4) return `0000${uuid}-0000-1000-8000-00805f9b34fb`
+    if (uuid.length === 8) return `${uuid}-0000-1000-8000-00805f9b34fb`
+    return uuid.toLowerCase()
+}
+
+const makeGattServer = (availableUuids = []) => {
+    const fullUuids = availableUuids.map(expandUUID)
+    return {
+        getPrimaryService: jest.fn().mockImplementation(uuid =>
+            fullUuids.includes(expandUUID(uuid))
+                ? Promise.resolve({ uuid: expandUUID(uuid) })
+                : Promise.reject(new Error('not found'))
+        ),
+        getPrimaryServices: jest.fn().mockResolvedValue(
+            fullUuids.map(uuid => ({ uuid }))
+        ),
+    }
+}
+
+const makeBleDevice = (id = 'dev-1', name = 'Test Device', gattServer = null) => ({
+    id,
+    name,
+    gatt: {
+        connected: false,
+        connect: jest.fn().mockResolvedValue(gattServer ?? makeGattServer()),
+        disconnect: jest.fn(),
+    },
+    addEventListener: jest.fn(),
+})
+
+const makeApi = (overrides = {}) => ({
+    startScanning: jest.fn(),
+    stopScanning: jest.fn(),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    getMac: jest.fn().mockReturnValue(null),
+    takeApproved: jest.fn().mockReturnValue(null),
+    ...overrides,
+})
+
+const flush = () => new Promise(resolve => setImmediate(resolve))
+
+beforeEach(() => {
+    jest.resetModules()
+    global.navigator = { bluetooth: makeBluetooth() }
+    WebBleIpcBinding = require('./ipc-binding')
+    WebBleIpcBinding._instance = undefined
+})
+
+afterEach(() => {
+    delete global.navigator
+})
+
+// ── state ────────────────────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — state', () => {
+
+    test('initial state is unknown', () => {
+        const binding = new WebBleIpcBinding()
+        expect(binding.state).toBe('unknown')
+    })
+
+    test('on stateChange emits poweredOn when navigator.bluetooth available', done => {
+        const binding = new WebBleIpcBinding()
+        binding.on('stateChange', state => {
+            expect(state).toBe('poweredOn')
+            expect(binding.state).toBe('poweredOn')
+            done()
+        })
+    })
+
+    test('on stateChange emits poweredOff when navigator.bluetooth absent', done => {
+        global.navigator = {}
+        const binding = new WebBleIpcBinding()
+        binding.on('stateChange', state => {
+            expect(state).toBe('poweredOff')
+            done()
+        })
+    })
+
+    test('stateChange is emitted exactly once even with multiple on() calls', done => {
+        const binding = new WebBleIpcBinding()
+        const calls = []
+        binding.on('stateChange', s => calls.push(s))
+        binding.on('stateChange', s => calls.push(s))
+
+        setTimeout(() => {
+            // One emission, two listeners → two calls total
+            expect(calls).toHaveLength(2)
+            done()
+        }, 50)
+    })
+
+    test('_bindings points to self', () => {
+        const binding = new WebBleIpcBinding()
+        expect(binding._bindings).toBe(binding)
+    })
+
+    test('_optionalServices contains full 128-bit UUIDs for fitness services', () => {
+        const binding = new WebBleIpcBinding()
+        expect(binding._optionalServices).toEqual(
+            expect.arrayContaining(['00001826-0000-1000-8000-00805f9b34fb'])
+        )
+        expect(binding._optionalServices.every(u => u.includes('-'))).toBe(true)
+    })
+
+    test('getInstance sets window._webBleBinding to the singleton', () => {
+        global.window = {}
+        const binding = WebBleIpcBinding.getInstance()
+        expect(global.window._webBleBinding).toBe(binding)
+        delete global.window
+    })
+
+})
+
+// ── setSupportedServices ──────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — setSupportedServices', () => {
+
+    let binding
+
+    beforeEach(() => {
+        binding = new WebBleIpcBinding()
+        binding.setApi(makeApi())
+    })
+
+    test('adds new services (any format) to optionalServices as full lowercase uuids', () => {
+        binding.setSupportedServices(['FD69', '0000000119ca465186e5fa29dcdd09d1'])
+
+        expect(binding._optionalServices).toContain('0000fd69-0000-1000-8000-00805f9b34fb')
+        expect(binding._optionalServices).toContain('00000001-19ca-4651-86e5-fa29dcdd09d1')
+    })
+
+    test('merges with built-in defaults — defaults are never lost', () => {
+        binding.setSupportedServices(['fd69'])
+
+        expect(binding._optionalServices).toContain(expandUUID('1826'))   // FTMS default
+        expect(binding._optionalServices).toContain(expandUUID('180d'))   // HR default
+        expect(binding._optionalServices).toContain(expandUUID('fd69'))
+    })
+
+    test('dedupes services that appear in defaults and announcement (different formats)', () => {
+        const before = binding._optionalServices.length
+        binding.setSupportedServices(['1826', '0000182600001000800000805F9B34FB'])
+
+        expect(binding._optionalServices.length).toBe(before)   // both map to existing FTMS
+    })
+
+    test('ignores empty or invalid input', () => {
+        const services = [...binding._optionalServices]
+        binding.setSupportedServices([])
+        binding.setSupportedServices(null)
+        binding.setSupportedServices('1826')
+        expect(binding._optionalServices).toEqual(services)
+    })
+
+    test('announced services are used for the per-UUID probe fallback', async () => {
+        binding.setSupportedServices(['fd69'])
+        const fullFd69 = expandUUID('fd69')
+        const server = {
+            getPrimaryServices: jest.fn().mockRejectedValue(new Error('not supported')),
+            getPrimaryService: jest.fn().mockImplementation(uuid =>
+                uuid === fullFd69 ? Promise.resolve({ uuid: fullFd69 }) : Promise.reject(new Error('not found'))
+            ),
+        }
+        const device = makeBleDevice('dev-1', 'New Trainer', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        // announced with the uuid in the form the devices lib registered it
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].advertisement.serviceUuids).toEqual(['fd69'])
+    })
+
+})
+
+// ── no-op methods ─────────────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — no-op methods', () => {
+
+    test('pauseLogging does not throw', () => {
+        expect(() => new WebBleIpcBinding().pauseLogging()).not.toThrow()
+    })
+
+    test('resumeLogging does not throw', () => {
+        expect(() => new WebBleIpcBinding().resumeLogging()).not.toThrow()
+    })
+
+    test('setServerDebug does not throw', () => {
+        expect(() => new WebBleIpcBinding().setServerDebug(true)).not.toThrow()
+    })
+
+})
+
+// ── startScanning ────────────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — startScanning', () => {
+
+    let binding, api
+
+    beforeEach(() => {
+        api = makeApi()
+        binding = new WebBleIpcBinding()
+        binding.setApi(api)
+    })
+
+    test('sends webble-start-scan to main via api.startScanning', () => {
+        binding.startScanning(['1234'], true, jest.fn())
+        expect(api.startScanning).toHaveBeenCalledWith(['1234'], true)
+    })
+
+    test('invokes callback immediately with null', () => {
+        const callback = jest.fn()
+        binding.startScanning([], false, callback)
+        expect(callback).toHaveBeenCalledWith(null)
+    })
+
+    test('resets stopRequested on each scan start', () => {
+        binding.stopRequested = true
+        binding.startScanning([], false, jest.fn())
+        expect(binding.stopRequested).toBe(false)
+    })
+
+    test('does not call requestDevice directly (scanning is driven by main process)', () => {
+        binding.startScanning([], false, jest.fn())
+        expect(global.navigator.bluetooth.requestDevice).not.toHaveBeenCalled()
+    })
+
+    test('re-emits discover with the MAC for known devices on subsequent startScanning', () => {
+        const entry = binding._cacheDevice(makeBleDevice('opaque-1', 'KICKR CORE'), 'F8:E1:A4:32:9C:09')
+        entry.probed = true
+        entry.serviceUuids = ['1826', '1818']
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        binding.startScanning([], true, jest.fn())
+
+        // entry is keyed under both opaque id and MAC — must be emitted only once
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].id).toBe('F8:E1:A4:32:9C:09')
+        expect(discovered[0].address).toBe('F8:E1:A4:32:9C:09')
+        expect(discovered[0].advertisement.serviceUuids).toEqual(['1826', '1818'])
+    })
+
+    test('does not re-emit devices without a known MAC (opaque id would poison address matching)', () => {
+        const entry = binding._cacheDevice(makeBleDevice('opaque-1', 'KICKR CORE'), null)
+        entry.probed = true
+        entry.serviceUuids = ['1826']
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        binding.startScanning([], true, jest.fn())
+
+        expect(discovered).toHaveLength(0)
+    })
+
+    test('does not re-emit devices that have not been probed yet', () => {
+        binding._cacheDevice(makeBleDevice('opaque-1', 'KICKR CORE'), 'F8:E1:A4:32:9C:09')
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        binding.startScanning([], true, jest.fn())
+
+        expect(discovered).toHaveLength(0)
+    })
+
+    test('emits no discover from cache when cache is empty', () => {
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        binding.startScanning([], true, jest.fn())
+
+        expect(discovered).toHaveLength(0)
+    })
+
+    test('calls _discoverApprovedDevices', () => {
+        jest.spyOn(binding, '_discoverApprovedDevices').mockResolvedValue()
+        binding.startScanning([], true, jest.fn())
+        expect(binding._discoverApprovedDevices).toHaveBeenCalled()
+    })
+
+})
+
+// ── _discoverApprovedDevices ──────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — _discoverApprovedDevices', () => {
+
+    let binding
+
+    beforeEach(() => {
+        binding = new WebBleIpcBinding()
+        binding.setApi(makeApi())
+        jest.spyOn(binding, '_processDiscoveredDevice').mockResolvedValue()
+    })
+
+    test('calls _processDiscoveredDevice with approved=false for each unknown device', async () => {
+        const dev1 = makeBleDevice('dev-1', 'KICKR')
+        const dev2 = makeBleDevice('dev-2', 'Volt')
+        global.navigator.bluetooth.getDevices.mockResolvedValue([dev1, dev2])
+
+        await binding._discoverApprovedDevices()
+
+        expect(binding._processDiscoveredDevice).toHaveBeenCalledWith(dev1, false)
+        expect(binding._processDiscoveredDevice).toHaveBeenCalledWith(dev2, false)
+    })
+
+    test('skips devices whose cache entry has already been probed', async () => {
+        const dev1 = makeBleDevice('dev-1', 'KICKR')
+        const dev2 = makeBleDevice('dev-2', 'Volt')
+        global.navigator.bluetooth.getDevices.mockResolvedValue([dev1, dev2])
+        const entry = binding._cacheDevice(dev1, null)
+        entry.probed = true
+
+        await binding._discoverApprovedDevices()
+
+        expect(binding._processDiscoveredDevice).not.toHaveBeenCalledWith(dev1, false)
+        expect(binding._processDiscoveredDevice).toHaveBeenCalledWith(dev2, false)
+    })
+
+    test('re-processes devices that are cached but not yet probed (failed probe retry)', async () => {
+        const dev1 = makeBleDevice('dev-1', 'KICKR')
+        global.navigator.bluetooth.getDevices.mockResolvedValue([dev1])
+        binding._cacheDevice(dev1, null)   // cached, probed stays false
+
+        await binding._discoverApprovedDevices()
+
+        expect(binding._processDiscoveredDevice).toHaveBeenCalledWith(dev1, false)
+    })
+
+    test('stops processing when stopRequested is set', async () => {
+        const dev1 = makeBleDevice('dev-1', 'KICKR')
+        const dev2 = makeBleDevice('dev-2', 'Volt')
+        global.navigator.bluetooth.getDevices.mockResolvedValue([dev1, dev2])
+
+        binding._processDiscoveredDevice.mockImplementation(async () => {
+            binding.stopRequested = true
+        })
+
+        await binding._discoverApprovedDevices()
+
+        expect(binding._processDiscoveredDevice).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not throw when getDevices is unavailable', async () => {
+        global.navigator.bluetooth.getDevices.mockRejectedValue(new Error('not supported'))
+        await expect(binding._discoverApprovedDevices()).resolves.not.toThrow()
+    })
+
+})
+
+// ── stopScanning ──────────────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — stopScanning', () => {
+
+    test('sets stopRequested to true', () => {
+        const binding = new WebBleIpcBinding()
+        binding.setApi(makeApi())
+
+        binding.stopScanning()
+
+        expect(binding.stopRequested).toBe(true)
+    })
+
+    test('calls api.stopScanning', () => {
+        const api = makeApi()
+        const binding = new WebBleIpcBinding()
+        binding.setApi(api)
+
+        binding.stopScanning()
+
+        expect(api.stopScanning).toHaveBeenCalled()
+    })
+
+    test('invokes callback when provided', () => {
+        const binding = new WebBleIpcBinding()
+        binding.setApi(makeApi())
+        const callback = jest.fn()
+
+        binding.stopScanning(callback)
+
+        expect(callback).toHaveBeenCalled()
+    })
+
+})
+
+// ── _processDiscoveredDevice ──────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — _processDiscoveredDevice', () => {
+
+    let binding, api
+
+    beforeEach(() => {
+        api = makeApi()
+        binding = new WebBleIpcBinding()
+        binding.setApi(api)
+    })
+
+    test('skips anonymous devices without GATT or emit and marks them probed', async () => {
+        const device = makeBleDevice('anon-1', null)
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(device.gatt.connect).not.toHaveBeenCalled()
+        expect(discovered).toHaveLength(0)
+        expect(binding._deviceCache.get('anon-1')).toBeDefined()
+        expect(binding._deviceCache.get('anon-1').probed).toBe(true)
+    })
+
+    test('approved device: consumes takeApproved and emits with the MAC as id/uuid/address', async () => {
+        api.takeApproved.mockReturnValue('F8:E1:A4:32:9C:09')
+        const server = makeGattServer(['1826'])
+        const device = makeBleDevice('opaque-id-1', 'KICKR CORE C378', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.takeApproved).toHaveBeenCalledWith('KICKR CORE C378')
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].id).toBe('F8:E1:A4:32:9C:09')
+        expect(discovered[0].uuid).toBe('F8:E1:A4:32:9C:09')
+        expect(discovered[0].address).toBe('F8:E1:A4:32:9C:09')
+        expect(discovered[0].name).toBe('KICKR CORE C378')
+    })
+
+    test('approved device: entry is reachable under both the MAC and the opaque id', async () => {
+        api.takeApproved.mockReturnValue('F8:E1:A4:32:9C:09')
+        const device = makeBleDevice('opaque-id-1', 'KICKR', makeGattServer(['1826']))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        const byMac = binding._deviceCache.get('F8:E1:A4:32:9C:09')
+        const byOpaque = binding._deviceCache.get('opaque-id-1')
+        expect(byMac).toBeDefined()
+        expect(byMac).toBe(byOpaque)
+        expect(byMac.device).toBe(device)
+    })
+
+    test('approved device: falls back to the opaque id when takeApproved returns null', async () => {
+        api.takeApproved.mockReturnValue(null)
+        const server = makeGattServer(['180d'])
+        const device = makeBleDevice('opaque-id-1', 'HRM Pro', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].id).toBe('opaque-id-1')
+        expect(discovered[0].address).toBe('opaque-id-1')
+    })
+
+    test('approved device: does not throw when api.takeApproved is not available (older shell)', async () => {
+        delete api.takeApproved
+        const server = makeGattServer(['180d'])
+        const device = makeBleDevice('opaque-id-1', 'HRM Pro', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].id).toBe('opaque-id-1')
+    })
+
+    test('getDevices path (approved=false): probes and caches but does NOT emit without a MAC', async () => {
+        const server = makeGattServer(['1826'])
+        const device = makeBleDevice('opaque-id-1', 'Volt', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, false)
+
+        expect(device.gatt.connect).toHaveBeenCalled()
+        expect(discovered).toHaveLength(0)
+        const entry = binding._deviceCache.get('opaque-id-1')
+        expect(entry.probed).toBe(true)
+        expect(entry.serviceUuids).toContain('1826')
+        // deferred device must resume advertising so the scan loop can approve it
+        expect(device.gatt.disconnect).toHaveBeenCalled()
+    })
+
+    test('getDevices path then scan approval: same opaque id is merged, MAC emitted without re-probe', async () => {
+        // second launch: getDevices() finds Volt before the scan loop has approved it
+        const server = makeGattServer(['1826'])
+        const device = makeBleDevice('opaque-id-1', 'Volt', server)
+        await binding._processDiscoveredDevice(device, false)
+        expect(device.gatt.connect).toHaveBeenCalledTimes(1)
+
+        // scan loop approves the same granted device → same session opaque id + MAC
+        api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(device.gatt.connect).toHaveBeenCalledTimes(1)   // no second probe
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].id).toBe('D4:C9:BB:7D:CB:AF')
+        expect(discovered[0].advertisement.serviceUuids).toEqual(['1826'])
+        expect(binding._deviceCache.get('D4:C9:BB:7D:CB:AF').device).toBe(device)
+    })
+
+    test('re-approval with same MAC but new opaque id: re-emits from cache and updates the device object', async () => {
+        api.takeApproved.mockReturnValue('F8:E1:A4:32:9C:09')
+        const device1 = makeBleDevice('opaque-id-1', 'KICKR CORE C378', makeGattServer(['1826']))
+        await binding._processDiscoveredDevice(device1, true)
+
+        // next scan: WebBLE handed out a new opaque id for the same physical device
+        api.takeApproved.mockReturnValue('F8:E1:A4:32:9C:09')
+        const device2 = makeBleDevice('opaque-id-2', 'KICKR CORE C378')
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device2, true)
+
+        expect(device2.gatt.connect).not.toHaveBeenCalled()   // no re-probe
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].id).toBe('F8:E1:A4:32:9C:09')
+        expect(discovered[0].advertisement.serviceUuids).toEqual(['1826'])
+        // device object refreshed so connects use the live grant
+        expect(binding._deviceCache.get('F8:E1:A4:32:9C:09').device).toBe(device2)
+    })
+
+    test('two devices sharing the same name get separate entries keyed by their MACs', async () => {
+        api.takeApproved.mockReturnValueOnce('AA:BB:CC:DD:EE:01')
+        const click1 = makeBleDevice('opaque-1', 'Zwift Click', makeGattServer(['00000001-19ca-4651-86e5-fa29dcdd09d1']))
+        await binding._processDiscoveredDevice(click1, true)
+
+        api.takeApproved.mockReturnValueOnce('AA:BB:CC:DD:EE:02')
+        const click2 = makeBleDevice('opaque-2', 'Zwift Click', makeGattServer(['00000001-19ca-4651-86e5-fa29dcdd09d1']))
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(click2, true)
+
+        // second Click was probed and emitted with its own MAC
+        expect(click2.gatt.connect).toHaveBeenCalled()
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].id).toBe('AA:BB:CC:DD:EE:02')
+
+        // each MAC resolves to its own physical device
+        expect(binding._deviceCache.get('AA:BB:CC:DD:EE:01').device).toBe(click1)
+        expect(binding._deviceCache.get('AA:BB:CC:DD:EE:02').device).toBe(click2)
+    })
+
+    test('emits discover with service UUIDs found on the device', async () => {
+        const server = makeGattServer(['1826', '1818'])
+        const device = makeBleDevice('dev-1', 'KICKR CORE', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].advertisement.serviceUuids).toContain('1826')
+        expect(discovered[0].advertisement.serviceUuids).toContain('1818')
+        expect(discovered[0].advertisement.serviceUuids).not.toContain('180d')
+    })
+
+    test('probe failure: emits nothing and stays retryable — succeeds on next encounter', async () => {
+        const device = makeBleDevice('dev-1', 'KICKR CORE')
+        device.gatt.connect.mockRejectedValueOnce(new Error('connection failed'))
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(0)
+        expect(binding._deviceCache.get('dev-1').probed).toBe(false)
+
+        // next encounter retries the probe and emits
+        device.gatt.connect.mockResolvedValue(makeGattServer(['1826']))
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].advertisement.serviceUuids).toEqual(['1826'])
+    })
+
+    test('probe timeout: a hanging GATT connect does not block processing forever', async () => {
+        binding._probeTimeoutMs = 50
+        const device = makeBleDevice('dev-1', 'Stuck Device')
+        device.gatt.connect.mockReturnValue(new Promise(() => {}))   // never settles
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(0)
+        expect(binding._deviceCache.get('dev-1').probed).toBe(false)
+    })
+
+    test('keeps the GATT connection open after a successful probe (announced device)', async () => {
+        const server = makeGattServer(['1826'])
+        const device = makeBleDevice('dev-1', 'Trainer', server)
+
+        await binding._processDiscoveredDevice(device, true)
+
+        // an immediate disconnect→connect cycle yields a dead server (Chromium/BlueZ
+        // race) — the connection is kept for the connect that follows the announcement
+        expect(device.gatt.disconnect).not.toHaveBeenCalled()
+    })
+
+    test('releases the probe connection after the grace period when no connect claims it', async () => {
+        binding._gattReleaseGraceMs = 20
+        const server = makeGattServer(['1826'])
+        const device = makeBleDevice('dev-1', 'Trainer', server)
+        device.gatt.connect.mockImplementation(async () => { device.gatt.connected = true; return server })
+
+        await binding._processDiscoveredDevice(device, true)
+        expect(device.gatt.disconnect).not.toHaveBeenCalled()
+
+        await new Promise(r => setTimeout(r, 60))
+        expect(device.gatt.disconnect).toHaveBeenCalled()
+    })
+
+    test('a connect within the grace period claims the connection — never released', async () => {
+        binding._gattReleaseGraceMs = 20
+        api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
+        const server = makeGattServer(['1826'])
+        const device = makeBleDevice('opaque-1', 'Volt', server)
+        device.gatt.connect.mockImplementation(async () => { device.gatt.connected = true; return server })
+
+        await binding._processDiscoveredDevice(device, true)
+
+        const peripheral = binding._createPeripheral({ id: 'D4:C9:BB:7D:CB:AF', name: 'Volt', serviceUuids: ['1826'] })
+        await peripheral.connectAsync()
+        expect(peripheral.state).toBe('connected')
+
+        await new Promise(r => setTimeout(r, 60))
+        expect(device.gatt.disconnect).not.toHaveBeenCalled()
+    })
+
+    test('attempts GATT disconnect when the probe fails', async () => {
+        const device = makeBleDevice('dev-1', 'Trainer')
+        device.gatt.connect.mockRejectedValue(new Error('boom'))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(device.gatt.disconnect).toHaveBeenCalled()
+    })
+
+    test('stores device and serviceUuids in cache after discovery', async () => {
+        const server = makeGattServer(['1826', '1818'])
+        const device = makeBleDevice('dev-1', 'KICKR', server)
+
+        await binding._processDiscoveredDevice(device, true)
+
+        const cached = binding._deviceCache.get('dev-1')
+        expect(cached).toBeDefined()
+        expect(cached.device).toBe(device)
+        expect(cached.serviceUuids).toContain('1826')
+        expect(cached.serviceUuids).toContain('1818')
+    })
+
+    test('emits discover even when no fitness services are found', async () => {
+        const server = makeGattServer([])
+        const device = makeBleDevice('dev-1', 'Unknown BLE', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].advertisement.serviceUuids).toEqual([])
+    })
+
+    test('falls back to per-UUID probing when getPrimaryServices throws (e.g. Wahoo KICKR)', async () => {
+        const fullUuids1826 = expandUUID('1826')
+        const server = {
+            getPrimaryServices: jest.fn().mockRejectedValue(new Error('Not supported')),
+            getPrimaryService: jest.fn().mockImplementation(uuid =>
+                uuid === fullUuids1826
+                    ? Promise.resolve({ uuid: fullUuids1826 })
+                    : Promise.reject(new Error('not found'))
+            ),
+        }
+        const device = makeBleDevice('dev-1', 'KICKR CORE', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].advertisement.serviceUuids).toContain('1826')
+    })
+
+    test('falls back to per-UUID probing when getPrimaryServices returns empty', async () => {
+        const fullUuids1818 = expandUUID('1818')
+        const server = {
+            getPrimaryServices: jest.fn().mockResolvedValue([]),
+            getPrimaryService: jest.fn().mockImplementation(uuid =>
+                uuid === fullUuids1818
+                    ? Promise.resolve({ uuid: fullUuids1818 })
+                    : Promise.reject(new Error('not found'))
+            ),
+        }
+        const device = makeBleDevice('dev-1', 'KICKR CORE', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].advertisement.serviceUuids).toContain('1818')
+    })
+
+    test('hands the device to a waiting connect request instead of probing', async () => {
+        api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
+        const device = makeBleDevice('opaque-id-1', 'Volt')
+
+        const waiter = binding._waitForDevice('D4:C9:BB:7D:CB:AF')
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        await expect(waiter).resolves.toBe(device)
+        expect(device.gatt.connect).not.toHaveBeenCalled()   // no probe while connect is waiting
+        expect(discovered).toHaveLength(0)
+    })
+
+    test('discovered peripheral has Noble-compatible shape', async () => {
+        const server = makeGattServer(['180d'])
+        const device = makeBleDevice('dev-1', 'HRM Pro', server)
+
+        let peripheral
+        binding.on('discover', p => { peripheral = p })
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(peripheral.id).toBe('dev-1')
+        expect(peripheral.uuid).toBe('dev-1')
+        expect(peripheral.address).toBe('dev-1')
+        expect(peripheral.advertisement.localName).toBe('HRM Pro')
+        expect(peripheral.advertisement.serviceUuids).toContain('180d')
+        expect(peripheral.state).toBe('disconnected')
+        expect(typeof peripheral.connectAsync).toBe('function')
+        expect(typeof peripheral.disconnect).toBe('function')
+        expect(typeof peripheral.disconnectAsync).toBe('function')
+        expect(typeof peripheral.discoverSomeServicesAndCharacteristicsAsync).toBe('function')
+        expect(typeof peripheral.discoverServicesAsync).toBe('function')
+        expect(typeof peripheral.on).toBe('function')
+        expect(typeof peripheral.emit).toBe('function')
+        expect(typeof peripheral.once).toBe('function')
+        expect(typeof peripheral.removeAllListeners).toBe('function')
+    })
+
+})
+
+// ── _connectPeripheral ────────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — _connectPeripheral', () => {
+
+    let binding, api
+
+    beforeEach(() => {
+        api = makeApi()
+        binding = new WebBleIpcBinding()
+        binding.setApi(api)
+        binding._gattRetryDelayMs = 1
+        binding._connectWaitTimeoutMs = 200
+    })
+
+    const getPeripheral = (id = 'dev-1', name = 'Trainer') =>
+        binding._createPeripheral({ id, name, serviceUuids: [] })
+
+    test('uses cached BluetoothDevice — no getDevices or requestDevice call', async () => {
+        const cachedDevice = makeBleDevice('dev-1')
+        binding._cacheDevice(cachedDevice, null)
+        global.navigator.bluetooth.requestDevice = jest.fn().mockRejectedValue(new Error('should not call'))
+
+        const peripheral = getPeripheral()
+        await peripheral.connectAsync()
+
+        expect(global.navigator.bluetooth.getDevices).not.toHaveBeenCalled()
+        expect(global.navigator.bluetooth.requestDevice).not.toHaveBeenCalled()
+        expect(cachedDevice.gatt.connect).toHaveBeenCalled()
+        expect(peripheral.state).toBe('connected')
+        expect(peripheral._server).toBeDefined()
+    })
+
+    test('resolves the cache by MAC when the device was approved with one (bug 1 regression)', async () => {
+        // scan loop discovered Volt: opaque id + MAC recorded via takeApproved
+        api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
+        const device = makeBleDevice('opaque-id-1', 'Volt', makeGattServer(['1826']))
+        await binding._processDiscoveredDevice(device, true)
+        global.navigator.bluetooth.requestDevice = jest.fn().mockRejectedValue(new Error('should not call'))
+        global.navigator.bluetooth.getDevices.mockClear()
+
+        // settings.json address is the MAC — the peripheral connects by MAC
+        const peripheral = getPeripheral('D4:C9:BB:7D:CB:AF', 'Volt')
+        await peripheral.connectAsync()
+
+        expect(global.navigator.bluetooth.getDevices).not.toHaveBeenCalled()
+        expect(global.navigator.bluetooth.requestDevice).not.toHaveBeenCalled()
+        expect(peripheral.state).toBe('connected')
+        expect(peripheral._server).toBeDefined()
+    })
+
+    test('falls back to getDevices exact-id match when device not in cache', async () => {
+        const existingDevice = makeBleDevice('dev-1')
+        global.navigator.bluetooth.getDevices.mockResolvedValue([existingDevice])
+        global.navigator.bluetooth.requestDevice = jest.fn().mockRejectedValue(new Error('should not call'))
+
+        const peripheral = getPeripheral()
+        await peripheral.connectAsync()
+
+        expect(global.navigator.bluetooth.getDevices).toHaveBeenCalled()
+        expect(global.navigator.bluetooth.requestDevice).not.toHaveBeenCalled()
+        expect(existingDevice.gatt.connect).toHaveBeenCalled()
+        expect(peripheral.state).toBe('connected')
+    })
+
+    test('never matches getDevices by name — names are not unique', async () => {
+        // a granted device shares the target name but is a DIFFERENT physical device
+        const wrongDevice = makeBleDevice('other-opaque-id', 'Zwift Click')
+        global.navigator.bluetooth.getDevices.mockResolvedValue([wrongDevice])
+
+        const peripheral = getPeripheral('AA:BB:CC:DD:EE:02', 'Zwift Click')
+        const connecting = peripheral.connectAsync()
+        await flush()
+
+        // binding asked main to approve the target instead of trusting the name match
+        expect(api.connect).toHaveBeenCalledWith('AA:BB:CC:DD:EE:02')
+
+        // main approves the right device; scan pipeline hands it over
+        api.takeApproved.mockReturnValue('AA:BB:CC:DD:EE:02')
+        const rightDevice = makeBleDevice('opaque-2', 'Zwift Click')
+        await binding._processDiscoveredDevice(rightDevice, true)
+
+        await connecting
+
+        expect(wrongDevice.gatt.connect).not.toHaveBeenCalled()
+        expect(rightDevice.gatt.connect).toHaveBeenCalled()
+        expect(peripheral.state).toBe('connected')
+    })
+
+    test('unknown device: asks main via api.connect and waits for the scan pipeline hand-over', async () => {
+        global.navigator.bluetooth.getDevices.mockResolvedValue([])
+
+        const peripheral = getPeripheral('D4:C9:BB:7D:CB:AF', 'Volt')
+        const connecting = peripheral.connectAsync()
+        await flush()
+
+        expect(api.connect).toHaveBeenCalledWith('D4:C9:BB:7D:CB:AF')
+        expect(global.navigator.bluetooth.requestDevice).not.toHaveBeenCalled()
+
+        api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
+        const device = makeBleDevice('opaque-1', 'Volt')
+        await binding._processDiscoveredDevice(device, true)
+
+        await connecting
+
+        expect(device.gatt.connect).toHaveBeenCalled()
+        expect(peripheral.state).toBe('connected')
+    })
+
+    test('rejects when the device never shows up within the wait timeout', async () => {
+        binding._connectWaitTimeoutMs = 50
+        global.navigator.bluetooth.getDevices.mockResolvedValue([])
+
+        const peripheral = getPeripheral('D4:C9:BB:7D:CB:AF', 'Volt')
+
+        await expect(peripheral.connectAsync()).rejects.toThrow('device not found')
+        expect(peripheral.state).toBe('disconnected')
+    })
+
+    test('retries GATT connect when the first attempt fails', async () => {
+        const device = makeBleDevice('dev-1')
+        device.gatt.connect
+            .mockRejectedValueOnce(new Error('flaky'))
+            .mockResolvedValueOnce(makeGattServer())
+        binding._cacheDevice(device, null)
+
+        const peripheral = getPeripheral()
+        await peripheral.connectAsync()
+
+        expect(device.gatt.connect).toHaveBeenCalledTimes(2)
+        expect(peripheral.state).toBe('connected')
+    })
+
+    test('rejects when all GATT connect attempts fail', async () => {
+        binding._gattConnectRetries = 2
+        const device = makeBleDevice('dev-1')
+        device.gatt.connect.mockRejectedValue(new Error('unreachable'))
+        binding._cacheDevice(device, null)
+
+        const peripheral = getPeripheral()
+
+        await expect(peripheral.connectAsync()).rejects.toThrow('unreachable')
+        expect(device.gatt.connect).toHaveBeenCalledTimes(2)
+        expect(peripheral.state).toBe('disconnected')
+    })
+
+    test('applies a timeout to hanging GATT connects', async () => {
+        binding._gattConnectTimeoutMs = 30
+        binding._gattConnectRetries = 1
+        const device = makeBleDevice('dev-1')
+        device.gatt.connect.mockReturnValue(new Promise(() => {}))   // never settles
+        binding._cacheDevice(device, null)
+
+        const peripheral = getPeripheral()
+
+        await expect(peripheral.connectAsync()).rejects.toThrow('timeout')
+    })
+
+    test('sets up gattserverdisconnected listener and emits disconnect event', async () => {
+        const device = makeBleDevice('dev-1')
+        let disconnectListener
+        device.addEventListener.mockImplementation((ev, fn) => {
+            if (ev === 'gattserverdisconnected') disconnectListener = fn
+        })
+        binding._cacheDevice(device, null)
+
+        const peripheral = getPeripheral()
+        await peripheral.connectAsync()
+
+        const events = []
+        peripheral.on('disconnect', () => events.push(true))
+
+        disconnectListener()
+
+        expect(peripheral.state).toBe('disconnected')
+        expect(events).toHaveLength(1)
+    })
+
+})
+
+// ── _disconnectPeripheral ─────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — _disconnectPeripheral', () => {
+
+    let binding
+
+    beforeEach(() => {
+        binding = new WebBleIpcBinding()
+        binding.setApi(makeApi())
+    })
+
+    const getPeripheral = () =>
+        binding._createPeripheral({ id: 'dev-1', name: 'Trainer', serviceUuids: [] })
+
+    test('calls gatt.disconnect when connected and sets state to disconnected', async () => {
+        const gattDisconnect = jest.fn()
+        const peripheral = getPeripheral()
+        peripheral._device = { gatt: { connected: true, disconnect: gattDisconnect } }
+        peripheral.state = 'connected'
+
+        await peripheral.disconnectAsync()
+
+        expect(gattDisconnect).toHaveBeenCalled()
+        expect(peripheral.state).toBe('disconnected')
+    })
+
+    test('does not throw when _device is not set', async () => {
+        const peripheral = getPeripheral()
+        await expect(peripheral.disconnectAsync()).resolves.not.toThrow()
+        expect(peripheral.state).toBe('disconnected')
+    })
+
+    test('callback form (disconnect) invokes callback with null', done => {
+        const peripheral = getPeripheral()
+        peripheral.disconnect(err => {
+            expect(err).toBeNull()
+            done()
+        })
+    })
+
+    test('clears the inUse claim so the release logic can act on later probes', async () => {
+        const device = makeBleDevice('dev-1', 'Trainer')
+        const entry = binding._cacheDevice(device, null)
+        entry.inUse = true
+
+        const peripheral = getPeripheral()
+        peripheral._device = device
+
+        await peripheral.disconnectAsync()
+
+        expect(entry.inUse).toBe(false)
+    })
+
+})
+
+// ── discovery: noble semantics (empty list = all) and uuid formats ────────────
+
+describe('WebBleIpcBinding — discovery noble semantics', () => {
+
+    let binding
+
+    beforeEach(() => {
+        binding = new WebBleIpcBinding()
+        binding.setApi(makeApi())
+    })
+
+    const getPeripheral = () =>
+        binding._createPeripheral({ id: 'dev-1', name: 'Volt', serviceUuids: [] })
+
+    test('discoverServicesAsync([]) returns ALL primary services', async () => {
+        const server = makeGattServer(['1826', '180d'])
+        server.connected = true
+        const peripheral = getPeripheral()
+        peripheral._server = server
+
+        const services = await peripheral.discoverServicesAsync([])
+
+        expect(services.map(s => s.uuid)).toEqual([expandUUID('1826'), expandUUID('180d')])
+    })
+
+    test('discoverServicesAsync([]) falls back to per-UUID probing when discover-all fails (Wahoo)', async () => {
+        const full1826 = expandUUID('1826')
+        const server = {
+            connected: true,
+            getPrimaryServices: jest.fn().mockRejectedValue(new Error('not supported')),
+            getPrimaryService: jest.fn().mockImplementation(uuid =>
+                uuid === full1826 ? Promise.resolve({ uuid: full1826 }) : Promise.reject(new Error('not found'))
+            ),
+        }
+        const peripheral = getPeripheral()
+        peripheral._server = server
+
+        const services = await peripheral.discoverServicesAsync([])
+
+        expect(services).toEqual([{ uuid: full1826 }])
+    })
+
+    test('discoverSomeServicesAndCharacteristicsAsync([],[]) returns all services and all characteristics', async () => {
+        const bleChar = {
+            uuid: expandUUID('2ad2'),
+            properties: { notify: true },
+            service: { uuid: expandUUID('1826') },
+        }
+        const service = { uuid: expandUUID('1826'), getCharacteristics: jest.fn().mockResolvedValue([bleChar]) }
+        const server = { connected: true, getPrimaryServices: jest.fn().mockResolvedValue([service]) }
+        const peripheral = getPeripheral()
+        peripheral._server = server
+
+        const result = await peripheral.discoverSomeServicesAndCharacteristicsAsync([], [])
+
+        expect(result.services).toEqual([{ uuid: expandUUID('1826') }])
+        expect(result.characteristics).toHaveLength(1)
+        expect(result.characteristics[0].uuid).toBe(expandUUID('2ad2'))
+        expect(result.characteristics[0].properties).toEqual(['notify'])
+    })
+
+    test('discoverSomeServicesAndCharacteristicsAsync([], target) accepts devices-layer uuid formats', async () => {
+        const bleChar = { uuid: expandUUID('2ad2'), properties: { notify: true }, service: { uuid: expandUUID('1826') } }
+        const service = {
+            uuid: expandUUID('1826'),
+            getCharacteristic: jest.fn().mockImplementation(uuid =>
+                uuid === expandUUID('2ad2') ? Promise.resolve(bleChar) : Promise.reject(new Error('not found'))
+            ),
+        }
+        const server = { connected: true, getPrimaryServices: jest.fn().mockResolvedValue([service]) }
+        const peripheral = getPeripheral()
+        peripheral._server = server
+
+        // devices layer fullUUID() produces dashed UPPERCASE
+        const result = await peripheral.discoverSomeServicesAndCharacteristicsAsync(
+            [], ['00002AD2-0000-1000-8000-00805F9B34FB'])
+
+        expect(service.getCharacteristic).toHaveBeenCalledWith(expandUUID('2ad2'))
+        expect(result.characteristics).toHaveLength(1)
+    })
+
+    test('discovery on a never-connected peripheral connects on demand via the device cache (KICKR regression)', async () => {
+        const bleChar = { uuid: expandUUID('2ad2'), properties: { notify: true }, service: { uuid: expandUUID('1826') } }
+        const service = { uuid: expandUUID('1826'), getCharacteristics: jest.fn().mockResolvedValue([bleChar]) }
+        const server = { connected: true, getPrimaryServices: jest.fn().mockResolvedValue([service]) }
+        const device = makeBleDevice('opaque-1', 'KICKR CORE C378', server)
+        binding._cacheDevice(device, 'F8:E1:A4:32:9C:09')
+
+        // devices layer thinks it is connected and skips connectAsync — _server is null
+        const peripheral = binding._createPeripheral({ id: 'F8:E1:A4:32:9C:09', name: 'KICKR CORE C378', serviceUuids: [] })
+
+        const result = await peripheral.discoverSomeServicesAndCharacteristicsAsync([], [])
+
+        expect(device.gatt.connect).toHaveBeenCalled()
+        expect(result.services).toEqual([{ uuid: expandUUID('1826') }])
+        expect(result.characteristics).toHaveLength(1)
+        expect(peripheral.state).toBe('connected')
+    })
+
+    test('discovery without server or cached device returns empty instead of throwing', async () => {
+        const peripheral = getPeripheral()   // no _server, no _device, nothing cached
+
+        const result = await peripheral.discoverSomeServicesAndCharacteristicsAsync([], [])
+        const services = await peripheral.discoverServicesAsync([])
+
+        expect(result).toEqual({ services: [], characteristics: [] })
+        expect(services).toEqual([])
+    })
+
+    test('explicit service uuids: noble short/dashless/uppercase forms resolve and are echoed back', async () => {
+        const server = makeGattServer(['180d'])
+        server.connected = true
+        const peripheral = getPeripheral()
+        peripheral._server = server
+
+        const services = await peripheral.discoverServicesAsync(
+            ['180D', '0000180D00001000800000805F9B34FB'])
+
+        // caller's own uuid format is preserved in the result
+        expect(services).toEqual([
+            { uuid: '180D' },
+            { uuid: '0000180D00001000800000805F9B34FB' },
+        ])
+    })
+
+})
+
+// ── dead-server recovery (service discovery after Chromium/BlueZ race) ────────
+
+describe('WebBleIpcBinding — dead-server recovery', () => {
+
+    let binding
+
+    beforeEach(() => {
+        binding = new WebBleIpcBinding()
+        binding.setApi(makeApi())
+        binding._gattRetryDelayMs = 1
+    })
+
+    const getPeripheral = (name = 'Volt') =>
+        binding._createPeripheral({ id: 'dev-1', name, serviceUuids: [] })
+
+    const makeDeadServer = () => ({
+        connected: false,
+        getPrimaryService: jest.fn().mockRejectedValue(new Error('GATT Server is disconnected')),
+    })
+
+    test('discoverServicesAsync reconnects and retries when the server is dead', async () => {
+        const liveServer = makeGattServer(['1826'])
+        liveServer.connected = true
+        const device = makeBleDevice('dev-1', 'Volt', liveServer)
+
+        const peripheral = getPeripheral()
+        peripheral._device = device
+        peripheral._server = makeDeadServer()
+
+        const services = await peripheral.discoverServicesAsync(['1826'])
+
+        expect(device.gatt.connect).toHaveBeenCalled()
+        expect(services).toEqual([{ uuid: '1826' }])
+        expect(peripheral._server).toBe(liveServer)
+        expect(peripheral.state).toBe('connected')
+    })
+
+    test('discoverSomeServicesAndCharacteristicsAsync recovers on a dead server', async () => {
+        const bleChar = {
+            uuid: expandUUID('2ad2'),
+            properties: { notify: true },
+            service: { uuid: expandUUID('1826') },
+        }
+        const service = { uuid: expandUUID('1826'), getCharacteristic: jest.fn().mockResolvedValue(bleChar) }
+        const liveServer = { connected: true, getPrimaryService: jest.fn().mockResolvedValue(service) }
+        const device = makeBleDevice('dev-1', 'Volt', liveServer)
+
+        const peripheral = getPeripheral()
+        peripheral._device = device
+        peripheral._server = makeDeadServer()
+
+        const result = await peripheral.discoverSomeServicesAndCharacteristicsAsync(['1826'], ['2ad2'])
+
+        expect(device.gatt.connect).toHaveBeenCalled()
+        expect(result.services).toEqual([{ uuid: '1826' }])
+        expect(result.characteristics).toHaveLength(1)
+        expect(result.characteristics[0].uuid).toBe(expandUUID('2ad2'))
+    })
+
+    test('does not reconnect when the server is connected and services are simply absent', async () => {
+        const server = makeGattServer([])
+        server.connected = true
+        const device = makeBleDevice('dev-1', 'Volt', server)
+
+        const peripheral = getPeripheral()
+        peripheral._device = device
+        peripheral._server = server
+
+        const services = await peripheral.discoverServicesAsync(['1826'])
+
+        expect(device.gatt.connect).not.toHaveBeenCalled()
+        expect(services).toEqual([])
+    })
+
+    test('returns the empty result when the reconnect itself fails', async () => {
+        binding._gattConnectRetries = 1
+        const device = makeBleDevice('dev-1', 'Volt')
+        device.gatt.connect.mockRejectedValue(new Error('unreachable'))
+
+        const peripheral = getPeripheral()
+        peripheral._device = device
+        peripheral._server = makeDeadServer()
+
+        const services = await peripheral.discoverServicesAsync(['1826'])
+
+        expect(services).toEqual([])
+    })
+
+})


### PR DESCRIPTION
## Summary

Implements WebBluetooth API via Chromium's `requestDevice()` on Linux, eliminating the root requirement that blocked AppImage/Snap/Flatpak distribution. The scan loop runs in the main process with synthetic user gestures; discovered devices are approved one per iteration and their MACs persisted to settings.json.

## What changed

- **Main process**: scan loop driven via `executeJavaScript()`, chooses one device per `requestDevice()` call, records MAC
- **Renderer**: `WebBleIpcBinding` extends EventEmitter with Noble-compatible methods (connect, discoverServices, subscribe)
- **GATT keep-alive**: connection retained 15s after probe to avoid disconnect→reconnect race (Chromium/BlueZ bug)
- **Dead-server recovery**: retries with reconnect when service discovery returns empty on a "connected" link
- **Dynamic services**: devices lib announces `setSupportedServices()` → new BLE services don't require desktop releases
- **No nameless approvals**: Chromium's "Unknown or Unsupported Device" placeholders are filtered out

## Test plan

- ✅ Fresh scan discovers multiple devices (Volt, KICKR CORE, HRM, Zwift Click)
- ✅ Pair trainer → connects, discovers services, subscribes to characteristics
- ✅ Restart app → auto-reconnects without re-scanning
- ✅ Switch trainers (Volt→KICKR) → connect flow handles on-demand server setup
- ✅ 248 unit tests pass; 14 desktop test suites, 1095 devices lib tests
- ✅ Desktop app runs with `npm run dev`

## Devices lib integration

Requires `devices` repo branch `feat/webble` (merged to main). Desktop automatically picks it up via Vite alias in dev mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)