### PR TITLE
fix: AppImage sandbox timing + drop incyclist-devices dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "electron": "^43.1.0",
         "electron-builder": "^26.8.1",
         "form-data": "^4.0.5",
-        "incyclist-devices": "^3.0.9",
         "jest": "^30.2.0",
         "lnk": "^1.1.0",
         "node-abi": "^4.27.0"
@@ -3219,13 +3218,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@protobuf-ts/runtime": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
-      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
-      "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
-    },
     "node_modules/@serialport/binding-mock": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
@@ -3266,19 +3258,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/@serialport/parser-byte-length": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-13.0.0.tgz",
-      "integrity": "sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-cctalk": {
@@ -3387,41 +3366,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/stream": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-13.0.0.tgz",
-      "integrity": "sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/bindings-interface": "1.2.2",
-        "debug": "4.4.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/stream/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -8874,54 +8818,6 @@
         "usb": "^2.16.0"
       }
     },
-    "node_modules/incyclist-devices": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.9.tgz",
-      "integrity": "sha512-OBz+5jklFk3C/j93kw7N1iUOzRkN/pmxMIps9fNGFglchz60gGRnt5Eogjw0oI+k8ZIfF5Bibrn6uzZWABx6KQ==",
-      "dev": true,
-      "dependencies": {
-        "@protobuf-ts/runtime": "^2.11.1",
-        "@serialport/bindings-interface": "^1.2.2",
-        "@serialport/parser-byte-length": "^13.0.0",
-        "@serialport/parser-delimiter": "^13.0.0",
-        "@serialport/parser-readline": "^13.0.0",
-        "@serialport/stream": "^13.0.0",
-        "incyclist-ant-plus": "^0.3.6",
-        "win32filetime": "^1.0.2"
-      },
-      "peerDependencies": {
-        "gd-eventlog": "^0.1.27"
-      }
-    },
-    "node_modules/incyclist-devices/node_modules/@serialport/parser-delimiter": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-13.0.0.tgz",
-      "integrity": "sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/incyclist-devices/node_modules/@serialport/parser-readline": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-13.0.0.tgz",
-      "integrity": "sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/parser-delimiter": "13.0.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -10741,16 +10637,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/lowercase-keys": {
@@ -14261,16 +14147,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/win32filetime": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/win32filetime/-/win32filetime-1.0.2.tgz",
-      "integrity": "sha512-UZi9pj1SNf4Y9EEmmorh7IvZ83S4aoOXg3AYbSfnlZjW1IP+ZGzZsnwEp9ydHlu4NTP8lTjowY7yndRDe74Pjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "long": "^3.1.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "electron": "^43.1.0",
     "electron-builder": "^26.8.1",
     "form-data": "^4.0.5",
-    "incyclist-devices": "^3.0.9",
     "jest": "^30.2.0",
     "lnk": "^1.1.0",
     "node-abi": "^4.27.0"

--- a/src/app.js
+++ b/src/app.js
@@ -31,8 +31,30 @@ class IncyclistApp
      * This workaround can be removed, when the app is converted to TypeScript
      * @returns {Promise<void>}
      */
+    /**
+     * Sets Electron command-line switches that must be applied before Chromium's
+     * native browser-process initialization begins (e.g. sandbox setup on Linux).
+     *
+     * Must be called synchronously, before any `await`, as early as possible in
+     * main.js. Calling it after an async gap (e.g. from within the constructor,
+     * which used to run only after the async init() dynamic import resolved) is
+     * too late: Chromium can already be spawning its zygote process on Linux by
+     * then, causing a FATAL setuid-sandbox abort when the AppImage's bundled
+     * chrome-sandbox helper isn't root-owned/4755.
+     */
+    static configureCommandLine() {
+        const environment = process.env.ENVIRONMENT ?? "prod";
+
+        if (process.platform==='linux' && !process.env.DEBUG && !process.env.LOADER_DEBUG && environment==='prod')  {
+            app.commandLine.appendSwitch('no-sandbox');
+        }
+        if (process.platform === 'linux') {
+            app.commandLine.appendSwitch('enable-experimental-web-platform-features')
+        }
+    }
+
     static async init() {
-        const UnhandledLib = await import('electron-unhandled'); 
+        const UnhandledLib = await import('electron-unhandled');
         unhandled = UnhandledLib.default;
     }
 
@@ -41,17 +63,10 @@ class IncyclistApp
         // all other initialization can be done in start())
 
         this.environment  = process.env.ENVIRONMENT ?? "prod";
-        
-        app.incyclistApp = this
 
+        app.incyclistApp = this
         if (process.platform==='darwin') {
             Menu.setApplicationMenu(null);
-        }
-        if (process.platform==='linux' && !process.env.DEBUG && !process.env.LOADER_DEBUG && this.environment==='prod')  {
-            app.commandLine.appendSwitch('no-sandbox');
-        }
-        if (process.platform === 'linux') {
-            app.commandLine.appendSwitch('enable-experimental-web-platform-features')
         }
 
 

--- a/src/features/serial/feature.js
+++ b/src/features/serial/feature.js
@@ -1,5 +1,5 @@
 const {ipcMain} = require('electron');
-const {TCPBinding} = require('incyclist-devices')
+const {TCPBinding} = require('./tcp-binding')
 const { autoDetect } = require('@serialport/bindings-cpp')
 const {IpcBinding,SerialIpcBinding,TCPIpcBinding} = require('./ipc-binding')
 const Feature = require("../base");

--- a/src/features/serial/tcp-binding.js
+++ b/src/features/serial/tcp-binding.js
@@ -1,0 +1,354 @@
+const { EventLogger } = require('gd-eventlog')
+const { networkInterfaces } = require('node:os')
+const net = require('node:net')
+
+/**
+ * Vendored from incyclist-devices (src/serial/bindings/tcp.ts).
+ *
+ * Kept as a local copy rather than a dependency on incyclist-devices: this app
+ * releases 2-4x/year while incyclist-devices publishes near-daily, and the
+ * binding only ever touched gd-eventlog and Node built-ins, so there is no
+ * real coupling to vendor against.
+ */
+
+const DEFAULT_TIMEOUT = 3000
+
+function resolveNextTick() {
+    return new Promise(resolve => process.nextTick(() => resolve()))
+}
+
+class CanceledError extends Error {
+    constructor(message) {
+        super(message)
+        this.canceled = true
+    }
+}
+
+function scanPort(host, port) {
+    return new Promise((resolve) => {
+        try {
+            const socket = new net.Socket()
+
+            const cleanup = () => {
+                try {
+                    socket.destroy()
+                }
+                catch {}
+                socket.removeAllListeners()
+            }
+
+            socket.setTimeout(1000)
+            socket.on('timeout', () => { resolve(false); cleanup() })
+            socket.on('error', () => { resolve(false); cleanup() })
+            socket.on('ready', () => { resolve(true); cleanup() })
+
+            socket.connect(port, host)
+        }
+        catch {
+            // just in case - this code should never be reached
+            resolve(false)
+        }
+    })
+}
+
+function scanSubNet(sn, port, excludeHosts) {
+    const range = []
+    for (let i = 1; i < 255; i++)
+        if (!excludeHosts?.includes(`${sn}.${i}`)) range.push(i)
+
+    return Promise.all(range.map(j => scanPort(`${sn}.${j}`, port).then(success => success ? `${sn}.${j}` : null).catch()))
+        .then(hosts => hosts.filter(h => h !== null))
+        .catch()
+}
+
+function getSubnets() {
+    const address = Object.keys(networkInterfaces())
+        .reduce((a, key) => [
+            ...a,
+            ...networkInterfaces()[key]
+        ], [])
+        .filter(iface => iface.family === 'IPv4' && !iface.internal && iface.netmask === '255.255.255.0')
+        .map(iface => {
+            const parts = iface.address.split('.')
+            return `${parts[0]}.${parts[1]}.${parts[2]}`
+        })
+
+    const subnets = address.filter((x, i) => i === address.indexOf(x))
+    subnets.push('127.0.0')
+    return subnets
+}
+
+class TCPPortBinding {
+    onDataHandler = this.onData.bind(this)
+    onErrorHandler = this.onError.bind(this)
+    onTimeoutHandler = this.onTimeout.bind(this)
+    onCloseHandler = this.onClose.bind(this)
+
+    constructor(socket, options) {
+        this.logger = new EventLogger('TCPPort')
+        this.socket = socket
+        this.openOptions = options
+        this.pendingRead = null
+        this.writeOperation = null
+        this.data = null
+
+        this.socket.removeAllListeners()
+        this.socket.on('data', this.onDataHandler)
+        this.socket.on('error', this.onErrorHandler)
+        this.socket.on('close', this.onCloseHandler)
+        this.socket.on('end', this.onCloseHandler)
+        this.socket.on('timeout', this.onTimeoutHandler)
+    }
+
+    get isOpen() {
+        return this.socket !== null
+    }
+
+    onData(data) {
+        if (!this.data) this.data = Buffer.alloc(0)
+        const buffer = Buffer.from(data)
+        this.data = Buffer.concat([this.data, buffer])
+
+        if (this.pendingRead) {
+            process.nextTick(this.pendingRead)
+            this.pendingRead = null
+        }
+    }
+
+    onError(err) {
+        this.logger.logEvent({ message: 'Port Error', error: err.message })
+        if (this.pendingRead) {
+            this.pendingRead(err)
+            this.socket = null
+        }
+    }
+
+    onTimeout() {
+        this.logger.logEvent({ message: 'Port Timeout' })
+        if (this.pendingRead) {
+            this.pendingRead(new Error('timeout'))
+        }
+    }
+
+    onClose() {
+        this.close()
+    }
+
+    async close() {
+        if (!this.isOpen)
+            return
+        this.data = Buffer.alloc(0)
+
+        const close = async () => {
+            return new Promise(done => {
+                const socket = this.socket
+                socket.on('error', () => { done(false) })
+                socket.on('close', () => { socket.removeAllListeners(); done(true) })
+                socket.destroy()
+            })
+        }
+
+        const closed = await close()
+
+        if (closed) {
+            this.socket = null
+            if (this.pendingRead) {
+                this.pendingRead(new CanceledError('port is closed'))
+            }
+        }
+    }
+
+    async read(buffer, offset, length) {
+        if (!this.isOpen) {
+            throw new Error('Port is not open')
+        }
+        if (!Buffer.isBuffer(buffer)) {
+            throw new TypeError('"buffer" is not a Buffer')
+        }
+        if (typeof offset !== 'number' || Number.isNaN(offset)) {
+            throw new TypeError(`"offset" is not an integer got "${Number.isNaN(offset) ? 'NaN' : typeof offset}"`)
+        }
+        if (typeof length !== 'number' || Number.isNaN(length)) {
+            throw new TypeError(`"length" is not an integer got "${Number.isNaN(length) ? 'NaN' : typeof length}"`)
+        }
+        if (buffer.length < offset + length) {
+            throw new Error('buffer is too small')
+        }
+
+        await resolveNextTick()
+
+        if (!this.data || this.data.length === 0) {
+            return new Promise((resolve, reject) => {
+                this.pendingRead = err => {
+                    if (err) {
+                        if (err.message === 'timeout') {
+                            resolve({ buffer: Buffer.from([]), bytesRead: 0 })
+                            return
+                        }
+                        return reject(err)
+                    }
+                    this.read(buffer, offset, length).then(resolve, reject)
+                }
+            })
+        }
+
+        const lengthToRead = length === 65536 ? this.data.length : length
+
+        const toCopy = this.data.slice(0, lengthToRead)
+        const bytesRead = toCopy.copy(buffer, offset)
+        this.data = this.data.slice(lengthToRead)
+        this.pendingRead = null
+
+        return ({ buffer, bytesRead })
+    }
+
+    write(buffer) {
+        if (!this.isOpen) {
+            throw new Error('Port is not open')
+        }
+
+        this.writeOperation = new Promise((resolve) => {
+            const run = async () => {
+                await resolveNextTick()
+
+                try {
+                    this.socket.write(buffer, () => {
+                        resolve()
+                    })
+                }
+                catch (err) {
+                    this.onError(err)
+                }
+            }
+
+            run()
+        })
+
+        return this.writeOperation
+    }
+
+    async update() {
+        await resolveNextTick()
+    }
+
+    async set() {
+        await resolveNextTick()
+    }
+
+    async get() {
+        if (!this.isOpen) {
+            throw new Error('Port is not open')
+        }
+        await resolveNextTick()
+        return {
+            cts: true,
+            dsr: false,
+            dcd: false,
+        }
+    }
+
+    async getBaudRate() {
+        return { baudRate: 9600 }
+    }
+
+    async flush() {
+        if (!this.isOpen) {
+            throw new Error('Port is not open')
+        }
+        await resolveNextTick()
+        this.data = Buffer.alloc(0)
+    }
+
+    async drain() {
+        if (!this.isOpen) {
+            throw new Error('Port is not open')
+        }
+        await resolveNextTick()
+        await this.writeOperation
+    }
+}
+
+const TCPBinding = {
+    /**
+     * Provides a list of hosts that have port #PORT opened
+     */
+    async list(port, excludeList) {
+        if (!port)
+            return []
+
+        const subnets = getSubnets()
+        let hosts = []
+
+        const excludeHosts = excludeList.map(e => e?.includes(':') ? e.split(':')[0] : e)
+
+        await Promise.all(
+            subnets.map(sn => scanSubNet(sn, port, excludeHosts).then(found => { hosts.push(...found) }))
+        )
+
+        return hosts.map(host => ({
+            path: `${host}:${port}`,
+            manufacturer: undefined,
+            locationId: undefined,
+            pnpId: undefined,
+            productId: undefined,
+            serialNumber: undefined,
+            vendorId: undefined
+        }))
+    },
+
+    /**
+     * Opens a connection to the serial port referenced by the path.
+     */
+    async open(options) {
+        const asyncOpen = () => {
+            return new Promise((resolve, reject) => {
+                let host, port
+
+                if (!options.path)
+                    return reject(new TypeError('"path" is not valid'))
+
+                try {
+                    const res = options.path.split(':')
+                    if (res.length !== 2)
+                        return reject(new TypeError('"path" is not valid'))
+                    host = res[0]
+                    port = Number(res[1])
+                    if (Number.isNaN(port))
+                        return reject(new TypeError('"path" is not valid'))
+                }
+                catch {
+                    return reject(new TypeError('"path" is not valid'))
+                }
+
+                const socket = new net.Socket()
+                socket.setTimeout(options.timeout || DEFAULT_TIMEOUT)
+
+                socket.once('timeout', () => { reject(new Error('timeout')) })
+                socket.once('error', (err) => { reject(err) })
+                socket.once('connect', () => { resolve(socket) })
+
+                socket.connect(port, host)
+            })
+        }
+
+        // This all can be actually ignored for the TCPBinding, but as they are all required, I need to setup some defaults
+        const openOptions = {
+            dataBits: 8,
+            lock: true,
+            stopBits: 1,
+            parity: 'none',
+            rtscts: false,
+            xon: false,
+            xoff: false,
+            xany: false,
+            hupcl: true,
+            ...options
+        }
+
+        const socket = await asyncOpen()
+
+        return new TCPPortBinding(socket, openOptions)
+    }
+}
+
+module.exports = { TCPBinding, TCPPortBinding, CanceledError, scanPort, scanSubNet, getSubnets }

--- a/src/features/serial/tcp-binding.test.js
+++ b/src/features/serial/tcp-binding.test.js
@@ -1,0 +1,91 @@
+const net = require('node:net')
+const { TCPBinding } = require('./tcp-binding')
+
+const TEST_PORT = 12345
+const TEST_PATH = `localhost:${TEST_PORT}`
+
+const sleep = (ms) => new Promise(done => setTimeout(done, ms))
+
+describe('TCPBinding', () => {
+
+    let server, serverSocket
+    const fnReceive = jest.fn()
+    const bindings = []
+
+    beforeEach(async () => {
+        fnReceive.mockClear()
+
+        server = net.createServer((socket) => {
+            serverSocket = socket
+            serverSocket.on('data', (data) => {
+                fnReceive(data)
+                serverSocket.write(Buffer.from(data.toString() + ' world'))
+            })
+        })
+
+        await new Promise(resolve => server.listen(TEST_PORT, 'localhost', resolve))
+    })
+
+    afterEach(async () => {
+        for (const b of bindings) {
+            try { await b.close() } catch {}
+        }
+        bindings.length = 0
+
+        if (serverSocket) {
+            serverSocket.removeAllListeners()
+            serverSocket.destroy()
+        }
+        await new Promise(resolve => server.close(resolve))
+    })
+
+    test('open - valid path connects', async () => {
+        const binding = await TCPBinding.open({ path: TEST_PATH })
+        bindings.push(binding)
+        expect(binding.isOpen).toBe(true)
+    })
+
+    test('open - missing path rejects', async () => {
+        await expect(TCPBinding.open({})).rejects.toThrow('"path" is not valid')
+    })
+
+    test('open - malformed path rejects', async () => {
+        await expect(TCPBinding.open({ path: 'localhost' })).rejects.toThrow('"path" is not valid')
+    })
+
+    test('open - unreachable port rejects', async () => {
+        await expect(TCPBinding.open({ path: 'localhost:65535', timeout: 200 })).rejects.toThrow()
+    })
+
+    test('write - server receives data', async () => {
+        const binding = await TCPBinding.open({ path: TEST_PATH })
+        bindings.push(binding)
+
+        await binding.write(Buffer.from('Hello'))
+        await sleep(50)
+
+        expect(fnReceive).toHaveBeenCalledWith(Buffer.from('Hello'))
+    })
+
+    test('read - resolves with echoed data', async () => {
+        const binding = await TCPBinding.open({ path: TEST_PATH })
+        bindings.push(binding)
+
+        await binding.write(Buffer.from('Hello'))
+        await sleep(50)
+
+        const buffer = Buffer.alloc(11)
+        const { bytesRead } = await binding.read(buffer, 0, 11)
+
+        expect(bytesRead).toBe(11)
+        expect(buffer.toString()).toBe('Hello world')
+    })
+
+    test('close - marks binding as closed', async () => {
+        const binding = await TCPBinding.open({ path: TEST_PATH })
+        bindings.push(binding)
+
+        await binding.close()
+        expect(binding.isOpen).toBe(false)
+    })
+})

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,11 @@ function isSquirrelBusy() {
     return require('electron-squirrel-startup')
 }
 
-if(isSquirrelBusy()) 
+if(isSquirrelBusy())
     process.exit();
 else {
+    Incyclist.configureCommandLine(); // must run synchronously, before any await, to apply before Chromium's native init
+
     Incyclist.init().then( ()=>{
         const app = new Incyclist()   
 


### PR DESCRIPTION
## Summary
- Move the Linux `no-sandbox` command-line switch to be set synchronously before any `await`, so it's applied before Chromium's native browser-process/zygote init begins. Previously it was set inside the `IncyclistApp` constructor, which only ran after an async `import('electron-unhandled')` resolved — a gap that let Chromium start sandbox setup first, causing a FATAL setuid-sandbox abort in the packaged AppImage.
- Remove the runtime dependency on `incyclist-devices` for the serial/TCP-IP feature. `TCPBinding` was listed under `devDependencies`, so electron-builder correctly pruned it from the packaged app, causing `Cannot find module 'incyclist-devices'` at startup once the sandbox crash above was fixed and the app got far enough to hit this `require()`. Since `TCPBinding`'s only real runtime dependencies are `gd-eventlog` and Node built-ins (its `@serialport/bindings-interface` import is TypeScript types only, erased at compile time), it's vendored directly into `desktop` (`src/features/serial/tcp-binding.js`) instead of pulling in the whole `incyclist-devices` package. This also decouples desktop's 2-4x/year release cadence from `incyclist-devices`' near-daily publishing.

## What changed
- `src/app.js` / `src/main.js`: extracted sandbox/command-line switch logic into `IncyclistApp.configureCommandLine()`, called synchronously as the first statement in `main.js`.
- `src/features/serial/feature.js`: requires the local `./tcp-binding` instead of `incyclist-devices`.
- `src/features/serial/tcp-binding.js`: vendored copy of `TCPBinding`/`TCPPortBinding` (new file).
- `src/features/serial/tcp-binding.test.js`: new unit tests covering open/write/read/close against a real TCP socket (new file).
- `package.json` / `package-lock.json`: removed `incyclist-devices` (9 packages dropped).

## Test plan
- [x] `npm test` — 263 tests pass (including 7 new tests for `tcp-binding.js`)
- [x] Linux AppImage built from this branch and manually verified by @Guido Doumen: app starts, BLE and TCP-IP/Serial both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)