### PR TITLE
Add OSM tile Referer/User-Agent headers (#174)

### DIFF
--- a/src/features/Network/NetworkFeature.js
+++ b/src/features/Network/NetworkFeature.js
@@ -114,7 +114,7 @@ class NetworkFeature extends Feature{
         }
 
         spec.registerFeatures( [
-            'network.scan', 'network.socket'
+            'network.scan', 'network.socket', 'network.openmap-referrer'
         ] )
         
         ipcRegisterBroadcast(spec.network,'network-socket-event',ipcRenderer)

--- a/src/features/Network/NetworkFeature.test.js
+++ b/src/features/Network/NetworkFeature.test.js
@@ -81,7 +81,7 @@ describe ('NetworkFeature',()=> {
 
             expect(res).toBeUndefined();  // does not return anything
             expect(utils.ipcCall).toHaveBeenCalledWith('network-scan',expect.anything())    // has registered ipc-call 'network-scan'
-            expect(api.registerFeatures).toHaveBeenCalledWith(['network.scan','network.socket']) ;           // has added 'network.scan' to  features array
+            expect(api.registerFeatures).toHaveBeenCalledWith(['network.scan','network.socket','network.openmap-referrer']) ;           // has added 'network.scan' to  features array
 
         })
         test('spec does not have registerFeatures function -> will throw an error',()=>{

--- a/src/web/pages/main.js
+++ b/src/web/pages/main.js
@@ -89,6 +89,14 @@ class MainWindow {
         this.win.webContents.session.webRequest.onErrorOccurred( (details)=> {
             this.requestLogger.log("Error loading: "+ details.url+":"+details.error);
         })
+        this.win.webContents.session.webRequest.onBeforeSendHeaders(
+            { urls: ['https://*.tile.openstreetmap.org/*'] },
+            (details, callback) => {
+                details.requestHeaders['Referer'] = 'https://incyclist.com';
+                details.requestHeaders['User-Agent'] = `Incyclist/${this.app.appVersion} (https://github.com/incyclist)`;
+                callback({ requestHeaders: details.requestHeaders });
+            }
+        );
         if ( this.oldWin)
             this.oldWin.win.hide();
 


### PR DESCRIPTION
## Summary
- OpenStreetMap's tile [usage policy](https://operations.osmfoundation.org/policies/tiles/) now requires a valid `Referer` and identifying `User-Agent` on tile requests
- Intercepts requests to `*.tile.openstreetmap.org` in `src/web/pages/main.js` and sets both headers
- Announces the new capability as `network.openmap-referrer` in `NetworkFeature.js` so `web-ui` can detect support in the installed desktop version

Fixes #174

## Test plan
- [x] `npm test` passes (263/263)
- [x] Verified in a running app that map tiles load with the correct `Referer`/`User-Agent` headers via DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)