### PR TITLE
Add IPC-exposed fetch feature for correct Overpass Referer header

### DIFF
--- a/src/features/fetch/feature.js
+++ b/src/features/fetch/feature.js
@@ -1,0 +1,91 @@
+const { ipcMain, net } = require('electron');
+const { EventLogger } = require('gd-eventlog');
+const Feature = require('../base');
+const { ipcCall, ipcHandle } = require('../utils');
+
+// singleton pattern
+class FetchFeature extends Feature {
+    static _instance;
+
+    constructor(props = {}) {
+        super(props)
+        this.logger = new EventLogger('fetch')
+    }
+
+    static getInstance() {
+        if (!FetchFeature._instance)
+            FetchFeature._instance = new FetchFeature()
+        return FetchFeature._instance
+    }
+
+    // Issues the request from the main process via Electron's net module, so a
+    // custom cross-origin Referer can be forced with referrerPolicy:'unsafe-url' -
+    // an option that only exists on net.request, not on the renderer's fetch/XHR.
+    async fetch(url, init = {}) {
+        const { method = 'GET', headers = {}, body, referrerPolicy } = init
+
+        return new Promise((resolve, reject) => {
+            let request
+            try {
+                request = net.request({ url, method, referrerPolicy })
+            }
+            catch (err) {
+                reject(err)
+                return
+            }
+
+            Object.entries(headers).forEach(([key, value]) => {
+                request.setHeader(key, value)
+            })
+
+            request.on('response', (response) => {
+                const chunks = []
+                response.on('data', (chunk) => chunks.push(chunk))
+                response.on('end', () => {
+                    const data = Buffer.concat(chunks).toString('utf-8')
+                    const responseHeaders = {}
+                    Object.entries(response.headers ?? {}).forEach(([key, value]) => {
+                        responseHeaders[key] = Array.isArray(value) ? value.join(', ') : value
+                    })
+
+                    resolve({
+                        ok: response.statusCode >= 200 && response.statusCode < 300,
+                        status: response.statusCode,
+                        statusText: response.statusMessage,
+                        headers: responseHeaders,
+                        data
+                    })
+                })
+                response.on('error', (err) => {
+                    this.logger.logEvent({ message: 'error', fn: 'fetch', url, error: err.message })
+                    reject(err)
+                })
+            })
+
+            request.on('error', (err) => {
+                this.logger.logEvent({ message: 'error', fn: 'fetch', url, error: err.message })
+                reject(err)
+            })
+
+            if (body !== undefined)
+                request.write(body)
+            request.end()
+        })
+    }
+
+    register(_props) {
+        ipcHandle('fetch-request', this.fetch.bind(this), ipcMain)
+    }
+
+    registerRenderer(spec, ipcRenderer) {
+        spec.fetch = {}
+        spec.fetch.request = ipcCall('fetch-request', ipcRenderer)
+
+        spec.registerFeatures([
+            'fetch', 'fetch.referrerPolicy'
+        ])
+    }
+
+}
+
+module.exports = FetchFeature

--- a/src/features/fetch/feature.js
+++ b/src/features/fetch/feature.js
@@ -3,6 +3,14 @@ const { EventLogger } = require('gd-eventlog');
 const Feature = require('../base');
 const { ipcCall, ipcHandle } = require('../utils');
 
+function toPlainHeaders(headers = {}) {
+    const result = {}
+    Object.entries(headers).forEach(([key, value]) => {
+        result[key] = Array.isArray(value) ? value.join(', ') : value
+    })
+    return result
+}
+
 // singleton pattern
 class FetchFeature extends Feature {
     static _instance;
@@ -34,43 +42,33 @@ class FetchFeature extends Feature {
                 return
             }
 
-            Object.entries(headers).forEach(([key, value]) => {
-                request.setHeader(key, value)
-            })
+            Object.entries(headers).forEach(([key, value]) => request.setHeader(key, value))
 
-            request.on('response', (response) => {
-                const chunks = []
-                response.on('data', (chunk) => chunks.push(chunk))
-                response.on('end', () => {
-                    const data = Buffer.concat(chunks).toString('utf-8')
-                    const responseHeaders = {}
-                    Object.entries(response.headers ?? {}).forEach(([key, value]) => {
-                        responseHeaders[key] = Array.isArray(value) ? value.join(', ') : value
-                    })
-
-                    resolve({
-                        ok: response.statusCode >= 200 && response.statusCode < 300,
-                        status: response.statusCode,
-                        statusText: response.statusMessage,
-                        headers: responseHeaders,
-                        data
-                    })
-                })
-                response.on('error', (err) => {
-                    this.logger.logEvent({ message: 'error', fn: 'fetch', url, error: err.message })
-                    reject(err)
-                })
-            })
-
-            request.on('error', (err) => {
-                this.logger.logEvent({ message: 'error', fn: 'fetch', url, error: err.message })
-                reject(err)
-            })
+            request.on('response', (response) => this._handleResponse(url, response, resolve, reject))
+            request.on('error', (err) => this._handleError(url, err, reject))
 
             if (body !== undefined)
                 request.write(body)
             request.end()
         })
+    }
+
+    _handleResponse(url, response, resolve, reject) {
+        const chunks = []
+        response.on('data', (chunk) => chunks.push(chunk))
+        response.on('end', () => resolve({
+            ok: response.statusCode >= 200 && response.statusCode < 300,
+            status: response.statusCode,
+            statusText: response.statusMessage,
+            headers: toPlainHeaders(response.headers),
+            data: Buffer.concat(chunks).toString('utf-8')
+        }))
+        response.on('error', (err) => this._handleError(url, err, reject))
+    }
+
+    _handleError(url, err, reject) {
+        this.logger.logEvent({ message: 'error', fn: 'fetch', url, error: err.message })
+        reject(err)
     }
 
     register(_props) {

--- a/src/features/fetch/feature.test.js
+++ b/src/features/fetch/feature.test.js
@@ -1,0 +1,149 @@
+const EventEmitter = require('node:events')
+
+jest.mock('electron', () => ({
+    ipcMain: { on: jest.fn() },
+    net: { request: jest.fn() },
+}))
+
+jest.mock('../utils', () => ({
+    ipcCall: jest.fn(),
+    ipcHandle: jest.fn(),
+}))
+
+const { ipcMain, net } = require('electron')
+const { ipcCall, ipcHandle } = require('../utils')
+const FetchFeature = require('./feature')
+
+class FakeIncomingMessage extends EventEmitter {
+    constructor(props = {}) {
+        super()
+        this.statusCode = props.statusCode ?? 200
+        this.statusMessage = props.statusMessage ?? 'OK'
+        this.headers = props.headers ?? {}
+    }
+}
+
+class FakeClientRequest extends EventEmitter {
+    constructor() {
+        super()
+        this.setHeader = jest.fn()
+        this.write = jest.fn()
+        this.end = jest.fn()
+    }
+}
+
+describe('FetchFeature', () => {
+
+    describe('getInstance', () => {
+        beforeEach(() => {
+            FetchFeature._instance = undefined
+        })
+
+        test('1st call -> creates new object', () => {
+            const f = FetchFeature.getInstance()
+            expect(f).toBeDefined()
+        })
+
+        test('2nd call -> returns previously created object', () => {
+            const f1 = FetchFeature.getInstance()
+            const f2 = FetchFeature.getInstance()
+            expect(f1).toBe(f2)
+        })
+    })
+
+    describe('fetch', () => {
+        let feature
+        let request
+
+        beforeEach(() => {
+            feature = new FetchFeature()
+            request = new FakeClientRequest()
+            net.request = jest.fn(() => request)
+        })
+
+        test('issues a GET by default and resolves with an axios/fetch-like response', async () => {
+            const promise = feature.fetch('https://overpass.example/api/interpreter')
+
+            const response = new FakeIncomingMessage({ statusCode: 200, statusMessage: 'OK', headers: { 'content-type': ['application/json'] } })
+            request.emit('response', response)
+            response.emit('data', Buffer.from('{"a":1}'))
+            response.emit('end')
+
+            const res = await promise
+
+            expect(net.request).toHaveBeenCalledWith({ url: 'https://overpass.example/api/interpreter', method: 'GET', referrerPolicy: undefined })
+            expect(request.end).toHaveBeenCalled()
+            expect(request.write).not.toHaveBeenCalled()
+            expect(res).toEqual({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+                data: '{"a":1}'
+            })
+        })
+
+        test('sends method, headers, body and referrerPolicy through to net.request', async () => {
+            const promise = feature.fetch('https://overpass.example/api/interpreter', {
+                method: 'POST',
+                headers: { 'User-Agent': 'Incyclist/1.0', 'Referer': 'https://incyclist.com' },
+                body: 'query-data',
+                referrerPolicy: 'unsafe-url'
+            })
+
+            expect(net.request).toHaveBeenCalledWith({ url: 'https://overpass.example/api/interpreter', method: 'POST', referrerPolicy: 'unsafe-url' })
+            expect(request.setHeader).toHaveBeenCalledWith('User-Agent', 'Incyclist/1.0')
+            expect(request.setHeader).toHaveBeenCalledWith('Referer', 'https://incyclist.com')
+            expect(request.write).toHaveBeenCalledWith('query-data')
+
+            const response = new FakeIncomingMessage({ statusCode: 400, statusMessage: 'Bad Request' })
+            request.emit('response', response)
+            response.emit('end')
+
+            const res = await promise
+            expect(res.ok).toBe(false)
+            expect(res.status).toBe(400)
+        })
+
+        test('rejects when the request emits an error', async () => {
+            const promise = feature.fetch('https://overpass.example/api/interpreter')
+            const error = new Error('network down')
+            request.emit('error', error)
+
+            await expect(promise).rejects.toBe(error)
+        })
+
+        test('rejects when the response emits an error', async () => {
+            const promise = feature.fetch('https://overpass.example/api/interpreter')
+            const response = new FakeIncomingMessage()
+            request.emit('response', response)
+            const error = new Error('stream broken')
+            response.emit('error', error)
+
+            await expect(promise).rejects.toBe(error)
+        })
+    })
+
+    describe('register', () => {
+        test('registers the fetch-request IPC handler', () => {
+            const feature = new FetchFeature()
+            feature.register()
+
+            expect(ipcHandle).toHaveBeenCalledWith('fetch-request', expect.any(Function), ipcMain)
+        })
+    })
+
+    describe('registerRenderer', () => {
+        test('exposes spec.fetch.request and announces capabilities', () => {
+            const feature = new FetchFeature()
+            const spec = { registerFeatures: jest.fn() }
+            const ipcRenderer = {}
+
+            feature.registerRenderer(spec, ipcRenderer)
+
+            expect(ipcCall).toHaveBeenCalledWith('fetch-request', ipcRenderer)
+            expect(spec.registerFeatures).toHaveBeenCalledWith(['fetch', 'fetch.referrerPolicy'])
+        })
+    })
+
+})

--- a/src/features/fetch/index.js
+++ b/src/features/fetch/index.js
@@ -1,0 +1,3 @@
+const FetchFeature = require('./feature')
+
+module.exports = FetchFeature

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -17,6 +17,7 @@ const OAuth = require('./oauth').getInstance()
 const Logging = require('./logging').getInstance()
 const DirectConnect = require('./direct-connect').getInstance()
 const Crypto = require('./crypto').getInstance()
+const Fetch = require('./fetch').getInstance()
 const {ObserverHandler} = require('./utils/observer')
 
 function initFeaturesApp( props ) {
@@ -42,6 +43,7 @@ function initFeaturesApp( props ) {
     Logging.register(props);
     DirectConnect.register(props);
     Crypto.register(props);
+    Fetch.register(props);
 
 }
 
@@ -81,6 +83,7 @@ function initFeaturesWeb( electron,ipcRenderer) {
     Crypto.registerRenderer(electron,ipcRenderer);
     Logging.registerRenderer(electron,ipcRenderer);
     DirectConnect.registerRenderer(electron,ipcRenderer);
+    Fetch.registerRenderer(electron,ipcRenderer);
 
 
     electron.skipInstallUpdate = ()=> {


### PR DESCRIPTION
## Summary
- Adds a new `fetch` feature (`src/features/fetch/feature.js`) that issues HTTP requests from the Electron main process via `net.request()`, supporting `referrerPolicy: 'unsafe-url'`.
- This is needed because Chromium's renderer network stack silently cancels cross-origin `Referer` headers set via `onBeforeSendHeaders` (see electron/electron#33092) - the Overpass API mirrors require a valid `Referer`/`User-Agent`, unlike OSM tiles (#174) which could use the `onBeforeSendHeaders` approach.
- Registered/announced following the existing feature pattern (`register` / `registerRenderer` / `registerFeatures(['fetch', 'fetch.referrerPolicy'])`), modeled on `NetworkFeature.js`.

Companion PRs:
- incyclist/services#feat/overpass-referrer-fix (adds `IFetchBinding` + wires `OverpassApi`)
- incyclist/web-ui#feat/overpass-referrer-fix (binding wiring)
- incyclist/mobile#feat/overpass-referrer-fix (mobile binding, uses RN's native fetch instead)

## Test plan
- [x] `npm test` (271 tests passing, including new `src/features/fetch/feature.test.js`)
- [x] Manual `npm run dev` smoke test of an Overpass-backed feature (e.g. route search) on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)