### PR TITLE
Announce webble capability on win32, gated by a web-ui feature toggle

### DIFF
--- a/src/features/webble/feature.js
+++ b/src/features/webble/feature.js
@@ -6,6 +6,12 @@ const { EventLogger } = require('gd-eventlog')
 
 const CONNECT_TARGET_TIMEOUT = 30 * 1000
 
+// linux has no native BLE binding, so WebBLE is its only option. win32 has WinrtBindings
+// as the default and stable path — WebBLE is announced there too so web-ui can opt
+// specific users into it behind a feature toggle, without desktop needing to know
+// about that toggle itself.
+const SUPPORTED_PLATFORMS = ['linux', 'win32']
+
 class WebBleFeature extends Feature {
     static _instance
 
@@ -240,7 +246,7 @@ class WebBleFeature extends Feature {
     }
 
     register(_props) {
-        if (process.platform !== 'linux') {
+        if (!SUPPORTED_PLATFORMS.includes(process.platform)) {
             return;
         }
         this.logger.logEvent({ message: 'register' })
@@ -259,7 +265,7 @@ class WebBleFeature extends Feature {
     }
 
     registerRenderer(spec, ipcRenderer) {
-        if (process.platform !== 'linux') {
+        if (!SUPPORTED_PLATFORMS.includes(process.platform)) {
             return;
         }
 

--- a/src/features/webble/feature.js
+++ b/src/features/webble/feature.js
@@ -10,7 +10,7 @@ const CONNECT_TARGET_TIMEOUT = 30 * 1000
 // as the default and stable path — WebBLE is announced there too so web-ui can opt
 // specific users into it behind a feature toggle, without desktop needing to know
 // about that toggle itself.
-const SUPPORTED_PLATFORMS = ['linux', 'win32']
+const SUPPORTED_PLATFORMS = new Set(['linux', 'win32'])
 
 class WebBleFeature extends Feature {
     static _instance
@@ -246,7 +246,7 @@ class WebBleFeature extends Feature {
     }
 
     register(_props) {
-        if (!SUPPORTED_PLATFORMS.includes(process.platform)) {
+        if (!SUPPORTED_PLATFORMS.has(process.platform)) {
             return;
         }
         this.logger.logEvent({ message: 'register' })
@@ -265,7 +265,7 @@ class WebBleFeature extends Feature {
     }
 
     registerRenderer(spec, ipcRenderer) {
-        if (!SUPPORTED_PLATFORMS.includes(process.platform)) {
+        if (!SUPPORTED_PLATFORMS.has(process.platform)) {
             return;
         }
 

--- a/src/features/webble/feature.test.js
+++ b/src/features/webble/feature.test.js
@@ -555,6 +555,77 @@ describe('WebBleFeature — register', () => {
 
 })
 
+describe('WebBleFeature — register (platform gating)', () => {
+
+    const withPlatform = (platform, fn) => {
+        const original = process.platform
+        Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+        try {
+            fn()
+        } finally {
+            Object.defineProperty(process, 'platform', { value: original, configurable: true })
+        }
+    }
+
+    test('registers on linux (no native BLE binding available)', () => {
+        withPlatform('linux', () => {
+            const feature = WebBleFeature.getInstance()
+            feature.register({})
+            expect(app.on).toHaveBeenCalledWith('web-contents-created', expect.any(Function))
+        })
+    })
+
+    test('registers on win32 too — announced so web-ui can opt testers in via a feature toggle', () => {
+        withPlatform('win32', () => {
+            const feature = WebBleFeature.getInstance()
+            feature.register({})
+            expect(app.on).toHaveBeenCalledWith('web-contents-created', expect.any(Function))
+        })
+    })
+
+    test('does not register on other platforms (e.g. darwin)', () => {
+        withPlatform('darwin', () => {
+            const feature = WebBleFeature.getInstance()
+            feature.register({})
+            expect(app.on).not.toHaveBeenCalled()
+        })
+    })
+
+})
+
+describe('WebBleFeature — registerRenderer (platform gating)', () => {
+
+    const withPlatform = (platform, fn) => {
+        const original = process.platform
+        Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+        try {
+            fn()
+        } finally {
+            Object.defineProperty(process, 'platform', { value: original, configurable: true })
+        }
+    }
+
+    test('announces webble capabilities on win32', () => {
+        withPlatform('win32', () => {
+            const spec = { registerFeatures: jest.fn() }
+            const feature = WebBleFeature.getInstance()
+            feature.registerRenderer(spec, { send: jest.fn(), on: jest.fn(), removeAllListeners: jest.fn() })
+            expect(spec.registerFeatures).toHaveBeenCalledWith(['webble', 'webble-services'])
+        })
+    })
+
+    test('does not populate spec.webble on darwin', () => {
+        withPlatform('darwin', () => {
+            const spec = { registerFeatures: jest.fn() }
+            const feature = WebBleFeature.getInstance()
+            feature.registerRenderer(spec, { send: jest.fn(), on: jest.fn(), removeAllListeners: jest.fn() })
+            expect(spec.webble).toBeUndefined()
+            expect(spec.registerFeatures).not.toHaveBeenCalled()
+        })
+    })
+
+})
+
 describe('WebBleFeature — registerRenderer', () => {
 
     let spec, ipcRenderer


### PR DESCRIPTION
## Summary
- Relaxes `WebBleFeature.register()`/`.registerRenderer()`'s platform gate from linux-only to `['linux', 'win32']`, so the `webble`/`webble-services` capabilities are also announced on Windows.
- Part of a 3-repo change (`services` / `desktop` / `web-ui`, same branch name): `desktop` just exposes the capability unconditionally on win32 (harmless — nothing calls it unless selected); `web-ui` is the one that decides whether to actually use it, based on the new `WEBBLE_WINDOWS` setting toggle added in `services`. `desktop` itself has no awareness of that toggle.
- Default behavior is unchanged: WinrtBindings remains what's actually used on Windows unless a tester's `settings.json` has `WEBBLE_WINDOWS: true` *and* web-ui picks `webble` accordingly.

## Test plan
- [x] Added platform-gating tests for both `register()` and `registerRenderer()` (linux registers, win32 now registers too, other platforms like darwin still don't) — previously these paths were only implicitly exercised by the ambient test-runner platform.
- [x] Full suite: `npm test` — 307/307 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)