### PR TITLE
fix: fetch secrets over network even when safeStorage is unavailable

### DIFF
--- a/src/features/secrets/feature.js
+++ b/src/features/secrets/feature.js
@@ -77,13 +77,19 @@ class SecretsFeature extends Feature {
 
     async performInit() {
         try {
-            if (!safeStorage.isEncryptionAvailable()) {
-                this.logger.logEvent({ message: 'safeStorage not available' });
-                this.currentStatus = 'missing';
-                return this.currentStatus;
+            const storageAvailable = safeStorage.isEncryptionAvailable();
+            if (!storageAvailable) {
+                this.logger.logEvent({
+                    message: 'safeStorage not available',
+                    selectedStorageBackend: safeStorage.getSelectedStorageBackend?.(),
+                });
             }
 
-            const cache = this._readCache();
+            // Without a working safeStorage backend we can neither read nor write the
+            // encrypted on-disk cache. Still attempt to fetch secrets over the network
+            // and keep them in memory for the lifetime of the process - re-fetching on
+            // every launch is strictly better than never fetching at all.
+            const cache = storageAvailable ? this._readCache() : null;
             const isOnline = net.isOnline();
             const expired = !cache || this._isExpired(cache.fetchedAt);
 
@@ -94,7 +100,7 @@ class SecretsFeature extends Feature {
                     this.currentStatus = 'missing';
                     return this.currentStatus;
                 }
-                return await this._runProvisioning();
+                return await this._runProvisioning(storageAvailable);
             }
 
             if (!isOnline) {
@@ -104,7 +110,7 @@ class SecretsFeature extends Feature {
                 return this.currentStatus;
             }
 
-            return await this._runStatusCheck(cache);
+            return await this._runStatusCheck(cache, storageAvailable);
         } catch (err) {
             this.logger.logEvent({ message: 'error', fn: 'performInit', error: err.message, stack: err.stack });
             this.currentStatus = 'missing';
@@ -112,7 +118,7 @@ class SecretsFeature extends Feature {
         }
     }
 
-    async _runStatusCheck(cache) {
+    async _runStatusCheck(cache, storageAvailable = true) {
         try {
             this.logger.logEvent({ message: 'check secret status' });
             const apiKey = cache.secrets?.INCYCLIST_API_KEY;
@@ -124,14 +130,15 @@ class SecretsFeature extends Feature {
             );
 
             if (response.status === 401)
-                return await this._runProvisioning();
+                return await this._runProvisioning(storageAvailable);
 
             if (response.ok) {
                 const data = response.data;
                 if (data.valid) {
                     this.currentSecrets = cache.secrets;
                 } else {
-                    this._writeCache({ secrets: data.secrets, expiresAt: data.expiresAt });
+                    if (storageAvailable)
+                        this._writeCache({ secrets: data.secrets, expiresAt: data.expiresAt });
                     this.currentSecrets = data.secrets;
                 }
                 this.currentStatus = 'ok';
@@ -154,7 +161,7 @@ class SecretsFeature extends Feature {
         return crypto.createHash('sha256').update(`${version}|${osInfo}|${uuid}`).digest('hex').slice(0, 32);
     }
 
-    async _runProvisioning() {
+    async _runProvisioning(storageAvailable = true) {
         try {
             this.logger.logEvent({ message: 'provisioning desktop secrets' });
             const version = app.getVersion();
@@ -177,7 +184,8 @@ class SecretsFeature extends Feature {
 
             if (response.ok) {
                 const data = response.data;
-                this._writeCache({ secrets: data.secrets, expiresAt: data.expiresAt });
+                if (storageAvailable)
+                    this._writeCache({ secrets: data.secrets, expiresAt: data.expiresAt });
                 this.currentSecrets = data.secrets;
                 this.currentStatus = 'ok';
                 this._pendingVerification = false;

--- a/src/features/secrets/feature.test.js
+++ b/src/features/secrets/feature.test.js
@@ -1,0 +1,130 @@
+jest.mock('electron', () => ({
+    ipcMain: { on: jest.fn() },
+    app: {
+        getVersion: jest.fn(() => '1.2.3'),
+        getPath: jest.fn(() => '/tmp/userData'),
+    },
+    powerMonitor: { on: jest.fn() },
+    net: { isOnline: jest.fn(() => true) },
+    safeStorage: {
+        isEncryptionAvailable: jest.fn(() => true),
+        getSelectedStorageBackend: jest.fn(() => 'gnome_libsecret'),
+        encryptString: jest.fn((s) => Buffer.from(s)),
+        decryptString: jest.fn((b) => b.toString()),
+    },
+}))
+
+jest.mock('../AppSettings', () => ({
+    getInstance: jest.fn(() => ({ settings: { uuid: 'test-uuid' } })),
+}))
+
+const { safeStorage, net } = require('electron')
+const AppSettings = require('../AppSettings')
+const SecretsFeature = require('./feature')
+
+describe('SecretsFeature', () => {
+    let feature
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        AppSettings.getInstance.mockReturnValue({ settings: { uuid: 'test-uuid' } })
+        safeStorage.isEncryptionAvailable.mockReturnValue(true)
+        safeStorage.getSelectedStorageBackend.mockReturnValue('gnome_libsecret')
+        net.isOnline.mockReturnValue(true)
+        process.env.ENVIRONMENT = 'prod'
+
+        feature = new SecretsFeature()
+        feature._readCache = jest.fn(() => null)
+        feature._writeCache = jest.fn()
+        feature._fetchWithTimeout = jest.fn()
+    })
+
+    afterEach(() => {
+        delete process.env.ENVIRONMENT
+    })
+
+    describe('performInit - safeStorage unavailable (fallback path)', () => {
+        beforeEach(() => {
+            safeStorage.isEncryptionAvailable.mockReturnValue(false)
+            safeStorage.getSelectedStorageBackend.mockReturnValue('basic_text')
+        })
+
+        test('still fetches secrets over the network via provisioning, without touching the cache', async () => {
+            feature._fetchWithTimeout = jest.fn(async () => ({
+                ok: true,
+                status: 200,
+                data: { secrets: { MQ_BROKER: 'broker.example.com' }, expiresAt: '2099-01-01T00:00:00.000Z' },
+            }))
+
+            const status = await feature.performInit()
+
+            expect(status).toBe('ok')
+            expect(feature.getSecret('MQ_BROKER')).toBe('broker.example.com')
+            expect(feature._readCache).not.toHaveBeenCalled()
+            expect(feature._writeCache).not.toHaveBeenCalled()
+        })
+
+        test('logs the selected storage backend alongside the safeStorage-unavailable event', async () => {
+            const logSpy = jest.spyOn(feature.logger, 'logEvent')
+            feature._fetchWithTimeout = jest.fn(async () => ({ ok: true, status: 200, data: { secrets: {}, expiresAt: null } }))
+
+            await feature.performInit()
+
+            expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+                message: 'safeStorage not available',
+                selectedStorageBackend: 'basic_text',
+            }))
+        })
+
+        test('provisioning failure -> status missing, cache still never touched', async () => {
+            feature._fetchWithTimeout = jest.fn(async () => ({ ok: false, status: 500, data: null }))
+
+            const status = await feature.performInit()
+
+            expect(status).toBe('missing')
+            expect(feature._readCache).not.toHaveBeenCalled()
+            expect(feature._writeCache).not.toHaveBeenCalled()
+        })
+
+        test('offline -> status missing without any network or cache calls', async () => {
+            net.isOnline.mockReturnValue(false)
+
+            const status = await feature.performInit()
+
+            expect(status).toBe('missing')
+            expect(feature._readCache).not.toHaveBeenCalled()
+            expect(feature._writeCache).not.toHaveBeenCalled()
+            expect(feature._fetchWithTimeout).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('performInit - safeStorage available (existing behaviour unchanged)', () => {
+        test('no cache -> provisions and writes cache', async () => {
+            feature._fetchWithTimeout = jest.fn(async () => ({
+                ok: true,
+                status: 200,
+                data: { secrets: { MQ_BROKER: 'broker.example.com' }, expiresAt: '2099-01-01T00:00:00.000Z' },
+            }))
+
+            const status = await feature.performInit()
+
+            expect(status).toBe('ok')
+            expect(feature._readCache).toHaveBeenCalled()
+            expect(feature._writeCache).toHaveBeenCalledWith({ secrets: { MQ_BROKER: 'broker.example.com' }, expiresAt: '2099-01-01T00:00:00.000Z' })
+        })
+    })
+
+    describe('getSecret', () => {
+        test('non-prod -> reads from process.env', () => {
+            process.env.ENVIRONMENT = 'dev'
+            process.env.MY_KEY = 'from-env'
+            const result = feature.getSecret('MY_KEY')
+            expect(result).toBe('from-env')
+            delete process.env.MY_KEY
+        })
+
+        test('prod, no secrets loaded -> empty string', () => {
+            expect(feature.getSecret('MQ_BROKER')).toBe('')
+        })
+    })
+})


### PR DESCRIPTION
## Summary

- `SecretsFeature.performInit()` used to bail out immediately when `safeStorage.isEncryptionAvailable()` was `false`, without ever attempting `_runProvisioning()`/`_runStatusCheck()`. This left any user whose OS keyring backend is unavailable or locked (e.g. a Linux machine with autologin, where PAM never captures a password to unlock gnome-keyring's `Login` collection) permanently unable to fetch secrets at all - including `MQ_BROKER`/`MQ_USER`/`MQ_PASSWORD` (consumed via `SecretsFeature.getInstance().getSecret(...)` in `src/features/mq.js`) and other secrets consumed by `incyclist-services` via `getSecretBindings().getSecret(key)`. The existing 60s retry loop didn't help, since it re-hit the same early-return guard every time.
- Confirmed via a real production log: an unattended Linux machine (autologin, launched via autostart, next to an exercise bike) reports `isEncryptionAvailable() === false` permanently, despite being online with a reachable secrets server.

## What changed

`src/features/secrets/feature.js`:
- When `safeStorage.isEncryptionAvailable()` is `false`, `performInit()` no longer returns early. It still attempts `_runProvisioning()`/`_runStatusCheck()` over the network, but skips `_readCache()`/`_writeCache()` entirely (there's no way to encrypt/decrypt the on-disk cache without a working backend). `currentSecrets` is kept in memory only for the process lifetime - the app re-fetches fresh on every launch in this situation, which is strictly better than never fetching at all.
- Added `safeStorage.getSelectedStorageBackend()` (e.g. `basic_text`, `gnome_libsecret`, `kwallet`) as an extra diagnostic field on the existing `safeStorage not available` log line, to help identify which backend is failing in the field.
- Out of scope (explicitly, per task): no `--password-store` switch, no keyring-prompt UX changes - that's a separate backlog item.

## Test plan

- Added `src/features/secrets/feature.test.js` covering:
  - `safeStorage.isEncryptionAvailable() === false` → `getSecret()` still returns a value fetched via a mocked network call, and `_readCache()`/`_writeCache()` are never called (success, provisioning-failure, and offline cases).
  - Diagnostic log line includes `selectedStorageBackend`.
  - Existing (`safeStorage` available) cache-read/write behaviour is unchanged.
- `npm test` - all 20 suites / 314 tests pass.