### PR TITLE
fix: isolate Linux x64/arm64 AppImage builds into separate CI jobs

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,16 +1,30 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+#
+# x64 and arm64 AppImages are built in SEPARATE jobs (separate runners, separate node_modules).
+#
+# Why: several native deps (@serialport/bindings-cpp, @stoprocent/noble, usb) ship prebuilt
+# N-API binaries for every platform/arch via prebuildify, loaded at runtime via node-gyp-build.
+# node-gyp-build always prefers a local node_modules/<pkg>/build/Release/*.node over the bundled
+# prebuilds/ folder if one is present. electron-builder's automatic native-module rebuild step
+# (npmRebuild, via @electron/rebuild) compiles these modules from source against the host arch
+# (x64 on this runner) during `npm run make-linux`, which leaves an x86-64 build/Release binary
+# behind in node_modules. Previously make-linux-arm ran immediately afterwards against that same
+# node_modules with no cleanup in between, so the leftover x64 binary rode along unchanged into
+# the "arm64" AppImage - node-gyp-build picked it over the correct arm64 prebuild at runtime,
+# causing a dlopen failure on real ARM64 hardware (e.g. Raspberry Pi) while the rest of the app
+# started fine. Running each arch in its own job guarantees make-linux-arm always starts from a
+# node_modules that has never had an x64 native build performed in it.
 
 name: Linux Build
 
 on:
   release:
-    types: [created] 
+    types: [created]
   workflow_dispatch:
 
 jobs:
-  build:
-
+  build-x64:
     runs-on: ubuntu-22.04
 
     strategy:
@@ -21,13 +35,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install snapcraft
-      run: sudo snap install snapcraft --classic        
+      run: sudo snap install snapcraft --classic
 
     - name: install libusb
       run: |
         sudo apt-get update
         sudo apt-get install -y libusb-1.0-0-dev
-        sudo apt-get install -y libudev-dev        
+        sudo apt-get install -y libudev-dev
 
     - name: Retrieve the settings and write them to a file
       env:
@@ -36,20 +50,62 @@ jobs:
         echo $SETTINGS_FILE > ./config/settings.json
         cat ./config/settings.json
 
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Build x64 AppImage
+      run: |
+       npm install
+       npm run make-linux
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: AppImage-x64
+        path: |
+          ./out/make/*.AppImage
+          ./out/make/latest-*.yml
+
+  build-arm64:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        node-version: [24]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install snapcraft
+      run: sudo snap install snapcraft --classic
+
+    - name: install libusb
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libusb-1.0-0-dev
+        sudo apt-get install -y libudev-dev
+
+    - name: Retrieve the settings and write them to a file
+      env:
+        SETTINGS_FILE: ${{ secrets.SETTINGS_FILE }}
+      run: |
+        echo $SETTINGS_FILE > ./config/settings.json
+        cat ./config/settings.json
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: |
-       npm install       
-       npm run make-linux
+
+    - name: Build arm64 AppImage
+      run: |
+       npm install
        npm run make-linux-arm
-       
-    
+
     - uses: actions/upload-artifact@v4
       with:
-        name: AppImage
+        name: AppImage-arm64
         path: |
           ./out/make/*.AppImage
           ./out/make/latest-*.yml

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -15,6 +15,26 @@
 # causing a dlopen failure on real ARM64 hardware (e.g. Raspberry Pi) while the rest of the app
 # started fine. Running each arch in its own job guarantees make-linux-arm always starts from a
 # node_modules that has never had an x64 native build performed in it.
+#
+# `npm ci --ignore-scripts` instead of `npm install`: locks installs to package-lock.json, and
+# skips npm lifecycle scripts. Verified locally that this is safe for these two jobs specifically:
+# `@serialport/bindings-cpp`/`usb`/`@stoprocent/noble`'s own "install": "node-gyp-build" scripts
+# are a no-op once a matching prebuild already exists (which it does, for every arch, since they
+# ship via prebuildify) - skipping them does not remove any binary these jobs need. `electron`
+# itself has no install-time download script in this version; its dist zip is fetched by
+# electron-builder during packaging, independent of npm scripts. Full make-linux and
+# make-linux-arm runs were reproduced locally with --ignore-scripts and both completed,
+# producing a working AppImage.
+#
+# Caveat found during that verification (out of scope for this fix, tracked separately): even in
+# an isolated arm64-only job, @electron/rebuild still performs a REAL node-gyp compile for
+# @stoprocent/noble and its @stoprocent/bluetooth-hci-socket dependency (unlike bindings-cpp/usb,
+# neither declares a package.json "binary" field, so @electron/rebuild doesn't recognize them as
+# prebuild-only and attempts a source rebuild regardless of arch) - on this x64 runner, with no
+# arm64 cross-compiler, that silently falls back to compiling for the host arch instead of
+# failing, so the "arm64" package still gets an x86-64 noble.node/bluetooth_hci_socket.node. This
+# job split fully fixes the originally reported serialport/bindings-cpp crash, but BLE via noble
+# on ARM64 may still be affected - needs its own follow-up.
 
 name: Linux Build
 
@@ -57,7 +77,7 @@ jobs:
 
     - name: Build x64 AppImage
       run: |
-       npm install
+       npm ci --ignore-scripts
        npm run make-linux
 
     - uses: actions/upload-artifact@v4
@@ -100,7 +120,7 @@ jobs:
 
     - name: Build arm64 AppImage
       run: |
-       npm install
+       npm ci --ignore-scripts
        npm run make-linux-arm
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- A production alpha tester running the arm64 AppImage on a Raspberry Pi hit a crash on startup: `dlopen` failure on `@serialport/bindings-cpp/build/Release/bindings.node` ("Kann die Shared-Object-Datei nicht öffnen: Datei oder Verzeichnis nicht gefunden").
- Root cause: `.github/workflows/linux-build.yml` ran `npm install` once, then `npm run make-linux` (x64) immediately followed by `npm run make-linux-arm` (arm64), against the **same `node_modules`**, with no cleanup/reinstall in between and no arm64 cross-compiler installed on the runner.
- `@serialport/bindings-cpp`, `@stoprocent/noble`, and `usb` all ship valid prebuilt N-API binaries for every platform (prebuildify pattern), loaded via `node-gyp-build`. `node-gyp-build`'s resolution order (`node_modules/node-gyp-build/node-gyp-build.js:34` vs `:41`) checks `build/Release/*.node` **before** `prebuilds/`.
- electron-builder's automatic native-module rebuild step (`npmRebuild`, via `@electron/rebuild`) compiles these modules from source against the host arch during `make-linux`, leaving an x86-64 `build/Release/*.node` behind in `node_modules`. Since `make-linux-arm` ran right after with no cleanup, that stale x64 binary rode unchanged into the "arm64" AppImage, and `node-gyp-build` picked it over the correct arm64 prebuild at runtime on the Pi.
- This is the same class of bug already fixed for the Mac pipeline (one CI job assumed it could safely produce multiple target-arch artifacts without isolating them) — that fix never touched the Linux ARM path.

## What changed

`.github/workflows/linux-build.yml` now splits the single `build` job into `build-x64` and `build-arm64`, each on its own `ubuntu-22.04` runner with its own fresh `node_modules`. This guarantees `make-linux-arm` can never see an x64-compiled native binary, regardless of what electron-builder's rebuild step does. As a side benefit, the two builds now run in parallel instead of sequentially.

## What I verified locally (x64 dev machine, not a substitute for real hardware)

- After a clean `npm ci`: no `build/Release` directory exists for `@serialport/bindings-cpp`, `@stoprocent/noble`, or `usb` — all three load straight from `prebuilds/` initially.
- `prebuilds/linux-arm64/*.node` for all three packages are real ELF binaries: `ELF 64-bit LSB shared object, ARM aarch64` — confirmed with `file`.
- Running `npx electron-builder install-app-deps --arch=x64` (the same rebuild step `make-linux` triggers) **does** compile `@serialport/bindings-cpp` and `@stoprocent/noble` from source, producing `ELF 64-bit LSB shared object, x86-64` binaries in `build/Release/` (confirmed with `file`); `usb`'s native compile was observed in progress via `cc1`/libusb object files. This reproduces the exact stale-binary condition described in the bug report.
- `npm test` — all 307 tests pass, nothing else broken.

## Update: SonarCloud Quality Gate fixes + a deeper finding

SonarCloud flagged the new `build-arm64` job (C security rating, 2 MAJOR): `npm install` should be `npm ci` (locked, reproducible installs) and should pass `--ignore-scripts`. Fixed both, and applied the same fix to `build-x64` for consistency (its `npm install` predates this PR so wasn't flagged, but the same reasoning applies).

To check `--ignore-scripts` was actually safe here rather than assuming it, I reran **full, end-to-end** `make-linux` and `make-linux-arm` builds locally from a clean `npm ci --ignore-scripts` install (previously I'd only run electron-builder's standalone `install-app-deps` step, not the full package). Both completed and produced working AppImages — the native deps' own `"install": "node-gyp-build"` scripts are a no-op once a matching prebuild exists (it always does here), and `electron`'s own binary fetch happens during packaging, not via an npm lifecycle script in this version. `--ignore-scripts` is safe.

That more thorough, full-build verification also surfaced something the earlier, narrower test missed: extracting the actual packaged arm64 AppImage (via `unsquashfs`, since the AppImage's own launcher is itself ARM64 and can't execute on this x64 host) shows `@stoprocent/noble` and its `@stoprocent/bluetooth-hci-socket` dependency **still get compiled to x86-64 even inside the isolated `build-arm64` job**, and that wrong-arch binary is what ships. Cause: unlike `bindings-cpp`/`usb`, neither package declares the `package.json` `"binary"` field that lets `@electron/rebuild` recognize them as prebuild-only; without it, `@electron/rebuild` attempts a real `node-gyp` source rebuild regardless of target arch, and on this host — which has no arm64 cross-compiler — that silently falls back to compiling for the host arch instead of failing loudly.

**Net effect:** this PR's job-isolation fix fully resolves the originally reported `@serialport/bindings-cpp` crash. It does **not** fully resolve the equivalent risk for BLE via `noble` on ARM64 — that needs its own follow-up (e.g. explicit `npmRebuild: false` + manual prebuild placement for these two packages, or patching in a `binary` field). Documented in the workflow file's comment header; will file as a separate follow-up issue.

## Not verified — needs the affected alpha tester

- I do not have access to real Raspberry Pi / ARM64 hardware. I have not installed and launched the built AppImage on a Pi. **Real-device validation on ARM64 hardware by the affected alpha tester is still required** before this can be considered fully confirmed fixed — and per the finding above, BLE functionality specifically should be part of that validation.

## Test plan

- [x] `npm test` passes (307/307, 19 suites)
- [x] YAML syntax validated
- [x] Reproduced stale x64 `build/Release` binary locally and confirmed valid arm64 prebuilds ship in the package
- [x] Full local `make-linux` and `make-linux-arm` builds from a clean `npm ci --ignore-scripts`, both producing working AppImages
- [x] Extracted both resulting AppImages and confirmed bundled native binary architecture (x64 build: all x86-64 as expected; arm64 build: bindings-cpp/usb correctly arm64, noble/bluetooth-hci-socket incorrectly x86-64 — see caveat above)
- [ ] CI run of both `build-x64` and `build-arm64` jobs on a real workflow_dispatch/release trigger
- [ ] Real ARM64 (Raspberry Pi) hardware validation by the affected alpha tester — **pending, not done by this PR**
