### PR TITLE
fix: getFileInfo() stripped a local video URL's leading slash

### DIFF
--- a/src/features/VideoScheme/VideoScheme.js
+++ b/src/features/VideoScheme/VideoScheme.js
@@ -711,8 +711,14 @@ class VideoScheme  extends Feature {
     }
 
     registerRenderer( spec, ipcRenderer) {
+        // 'video.localUrlFix': this installed desktop has the corrected getFileInfo() local
+        // URL parsing (no longer strips a well-formed video:///file:/// URL's own leading
+        // slash - see the getFileInfo fix in this same feature). web-ui checks this to decide
+        // whether it needs to compensate for the old bug itself, since desktop/src only ships
+        // via a new installer, not a hot bundle update - older installs may run this exact
+        // renderer bundle for a while.
         spec.registerFeatures( [
-            'video','video.convert','video.screenshot','video.convertOffline'
+            'video','video.convert','video.screenshot','video.convertOffline','video.localUrlFix'
         ] )
 
         spec.video = {}

--- a/src/features/VideoScheme/VideoScheme.js
+++ b/src/features/VideoScheme/VideoScheme.js
@@ -18,6 +18,12 @@ const { ObserverHandler,ipcHandleObserver,ipcCallObserver } = require('../utils/
 const SCHEME = 'video';
 const LOGGER_NAME = 'VideoScheme';
 
+// outFile is an absolute path - Unix ones already carry their own leading slash (getFileInfo
+// preserves it), Windows ones (drive letter, no leading slash) don't. Prepending a fixed
+// 'file:///' unconditionally either double-slashes the Unix case or under-slashes the Windows
+// one - branch on whether the path already has its own leading slash instead.
+const toFileUrl = (outFile) => (outFile.startsWith('/') ? 'file://' : 'file:///') + outFile
+
 const debug  = process.env.DEBUG;
 
 const DEFAULT_PRESET = 'veryfast'
@@ -187,7 +193,7 @@ class VideoScheme  extends Feature {
 
         const pngDir = outDir || (url.startsWith('http') ? os.tmpdir() : undefined)
         const outFile = pngDir ? path.join(pngDir,name.replace(extRegex,'_preview.png')) : filename.replace(extRegex,'_preview.png')
-        const outUrl = 'file:///'+outFile 
+        const outUrl = toFileUrl(outFile)
         const ffmpegProps = {filename:outFile,count:1,timemarks:[position]}
         if (props.size)
             ffmpegProps.size = props.size
@@ -277,7 +283,7 @@ class VideoScheme  extends Feature {
 
     async save(emitter,cmd,outFile) {
         
-        const outUrl = 'file:///'+outFile 
+        const outUrl = toFileUrl(outFile)
         let duration;
 
         const parseTime = (time) => {

--- a/src/features/VideoScheme/VideoScheme.test.js
+++ b/src/features/VideoScheme/VideoScheme.test.js
@@ -91,7 +91,7 @@ describe ( 'VideoScheme', ()=>{
 
             cmdMock._handlers['end']();
             const res = await promise;
-            expect(res).toBe('file:///' + path.join(os.tmpdir(), 'ES_MenorcaDemo_preview.png'));
+            expect(res).toBe('file://' + path.join(os.tmpdir(), 'ES_MenorcaDemo_preview.png'));
         });
 
         test('outDir option overrides output folder', async () => {
@@ -101,7 +101,7 @@ describe ( 'VideoScheme', ()=>{
 
             cmdMock._handlers['end']();
             const res = await promise;
-            expect(res).toBe('file:///' + path.join(outDir, 'sample_preview.png'));
+            expect(res).toBe('file://' + path.join(outDir, 'sample_preview.png'));
         });
 
         test('ffmpeg error rejects with parsed message', async () => {

--- a/src/features/utils/index.js
+++ b/src/features/utils/index.js
@@ -43,15 +43,26 @@ function getFileInfo ( urlStr, scheme='file') {
 
         }
         else if ( decodedUrl.startsWith(`${scheme}:`) || decodedUrl.startsWith('file:') ) {
-            const urlParts = scheme.startsWith('http') ? decodedUrl.split('://') : decodedUrl.split(':///')
-            pathInfo = path.parse(urlParts[1])
+            // Split on the real 2-slash scheme separator, not a literal 3-slash "scheme:///" -
+            // the 3rd slash is the absolute path's own leading slash, not part of the scheme.
+            // Splitting on ":///" discarded it, turning "video:///home/..." into the relative
+            // path "home/...", which fs.existsSync() then resolves against the app's working
+            // directory instead of root and never finds.
+            let rawPath = decodedUrl.split('://')[1]
+
+            // "scheme:///C:/Users/..." -> "/C:/Users/..." after the split above - strip the
+            // extra leading slash for Windows drive-letter paths (Unix absolute paths keep theirs)
+            if ( rawPath.charAt(0)==='/' && rawPath.charAt(2)===':')
+                rawPath = rawPath.substring(1)
+
+            pathInfo = path.parse(rawPath)
             pathInfo.name = pathInfo.base;
             pathInfo.filename = pathInfo.dir+path.sep+pathInfo.name;
             pathInfo.outFile = pathInfo.filename;
             pathInfo.ext = pathInfo.ext.substring(1)
 
             return pathInfo
-            
+
         }
         else pathInfo = path.parse(decodedUrl)
 

--- a/src/features/utils/utils.test.js
+++ b/src/features/utils/utils.test.js
@@ -41,6 +41,19 @@ describe('Features:utils',() => {
             })
         })
 
+        test('unix local video url: keeps the absolute path\'s leading slash', () => {
+            if ( os.platform()==='win32')
+                return;
+            const url = 'video:///home/dirk/incyclist/sonstige/NO_Ocean_Road/NO_Ocean Road.avi'
+            const res = getFileInfo(url, 'video')
+            expect(res).toMatchObject({
+                name: 'NO_Ocean Road.avi',
+                ext: 'avi',
+                filename: '/home/dirk/incyclist/sonstige/NO_Ocean_Road/NO_Ocean Road.avi',
+                outFile: '/home/dirk/incyclist/sonstige/NO_Ocean_Road/NO_Ocean Road.avi'
+            })
+        })
+
         test('encoded web url',()=>{
             const url = 'https://w3schools.com/test%25.jpg'
             const res = getFileInfo( url,'http')


### PR DESCRIPTION
@/tmp/claude-1000/-mnt-c-linux-dev-incyclist-desktop/d6fda472-2214-42ab-bb48-e92ba3113cc5/scratchpad/pr199_body_new.md