### PR TITLE
fix: open Strava/intervals.icu OAuth in the system browser instead of an embedded window

### DIFF
--- a/src/features/oauth/feature.js
+++ b/src/features/oauth/feature.js
@@ -3,6 +3,8 @@ const {ipcMain,app,shell} = require('electron');
 const {ipcCall, ipcCallNoResponse, ipcHandle, ipcHandleNoResponse} = require ('../utils');
 const EventEmitter = require('node:events');
 const http = require('node:http');
+const crypto = require('node:crypto');
+const axios = require('axios');
 const { EventLogger } = require('gd-eventlog');
 
 const OAUTH_SERVER = 'https://auth.incyclist.com/';
@@ -36,9 +38,20 @@ class OauthFeature extends Feature{
     // http://127.0.0.1:<ephemeral-port>/callback instead of a custom URL
     // scheme, so no OS-level protocol registration/packaging changes are
     // needed on any platform, and it works identically in dev and packaged
-    // builds. auth-server's success.ejs/error.ejs need no changes: they
-    // already just echo whatever `sid` they were given back as a redirect
-    // target, so a loopback URL works exactly like the incyclist:// one does.
+    // builds.
+    //
+    // Uses PKCE: a random verifier is generated here and never leaves this
+    // process; only its SHA-256 hash (the "challenge") goes into the browser
+    // URL. auth-server hands back a short-lived, single-use exchange code via
+    // the browser redirect - not the real tokens, since anything placed in
+    // that redirect is reachable by any local process willing to bind a port
+    // on 127.0.0.1. The real tokens are only ever obtained via the direct,
+    // off-browser POST below, which requires presenting the matching
+    // verifier. This closes off a malicious local listener intercepting
+    // *this* flow's tokens; it does not (and structurally cannot, for an
+    // open-source client) stop a malicious local process from phishing the
+    // user through its own, independently-constructed consent flow - see
+    // PR discussion for incyclist-desktop#201 / microservices#133.
     //
     // Trade-off accepted: unlike the embedded-window flow (which could detect
     // the user closing the window as an explicit cancel), there is no signal
@@ -46,6 +59,9 @@ class OauthFeature extends Feature{
     // cancelling - the request just times out after AUTH_TIMEOUT_MS.
     authorize(provider) {
         const oauthUrl = (app.incyclistApp.settings.oauthUrl || OAUTH_SERVER).replace(/\/+$/,'')
+
+        const codeVerifier = crypto.randomBytes(32).toString('base64url')
+        const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url')
 
         return new Promise( done => {
             let completed = false
@@ -60,6 +76,17 @@ class OauthFeature extends Feature{
                 if (server)
                     server.close()
                 done(result)
+            }
+
+            const exchangeCode = async (code) => {
+                try {
+                    const res = await axios.post(`${oauthUrl}/${provider}/token`, {code, code_verifier: codeVerifier})
+                    finish({success:true, user: res.data?.user})
+                }
+                catch (err) {
+                    this.logger.logEvent({message:'oauth code exchange failed', provider, error:err.message})
+                    finish({success:false, reason:'code exchange failed'})
+                }
             }
 
             server = http.createServer( (req,res) => {
@@ -85,15 +112,13 @@ class OauthFeature extends Feature{
                     return
                 }
 
-                // Mirrors success.ejs, which spreads whatever fields exist on
-                // user.auth.strava/intervals into the redirect's query string -
-                // pass all of them through unchanged rather than assuming a
-                // fixed set of field names.
-                const authData = {}
-                for (const [key,value] of params.entries())
-                    authData[key] = value
+                const code = params.get('code')
+                if (!code) {
+                    finish({success:false, reason:'no code in callback'})
+                    return
+                }
 
-                finish({success:true, user:{auth:{[provider]:authData}}})
+                exchangeCode(code)
             })
 
             server.on('error', (err) => {
@@ -105,6 +130,7 @@ class OauthFeature extends Feature{
                 const port = server.address().port
                 const redirectUri = `http://127.0.0.1:${port}/callback`
                 const authUrl = `${oauthUrl}/${provider}?sid=${encodeURIComponent(redirectUri)}`
+                    +`&code_challenge=${encodeURIComponent(codeChallenge)}&code_challenge_method=S256`
 
                 this.logger.logEvent({message:'opening system browser for oauth', provider, port})
                 shell.openExternal(authUrl).catch( (err) => {

--- a/src/features/oauth/feature.js
+++ b/src/features/oauth/feature.js
@@ -1,14 +1,19 @@
 const Feature = require('../base');
-const {ipcMain,app} = require('electron');
+const {ipcMain,app,shell} = require('electron');
 const {ipcCall, ipcCallNoResponse, ipcHandle, ipcHandleNoResponse} = require ('../utils');
 const EventEmitter = require('node:events');
-const OAuthWindow = require('../../web/pages/oauth');
+const http = require('node:http');
 const { EventLogger } = require('gd-eventlog');
+
+const OAUTH_SERVER = 'https://auth.incyclist.com/';
+const AUTH_TIMEOUT_MS = 5*60*1000; // give the user enough time to log in + solve a captcha
+
+const CALLBACK_RESPONSE_HTML = '<html><body>You can close this window and return to Incyclist.</body></html>';
 
 class OauthFeature extends Feature{
 
     static _instance;
-    
+
     constructor() {
         super()
         this.oauthSessions = [];
@@ -22,48 +27,96 @@ class OauthFeature extends Feature{
         return OauthFeature._instance;
     }
 
-    authorize(provider) {       
-        let completed = false
-        return new Promise ( done => {
+    // Opens the OAuth provider's login page in the user's real, default system
+    // browser (rather than an embedded Electron BrowserWindow) and gets the
+    // result back via a short-lived loopback HTTP server, the same pattern
+    // used by most desktop OAuth clients (gcloud, VS Code, ...) and
+    // conceptually equivalent to the redirect_uri mobile already uses
+    // (incyclist://oauth/callback) - here the "redirect_uri" is
+    // http://127.0.0.1:<ephemeral-port>/callback instead of a custom URL
+    // scheme, so no OS-level protocol registration/packaging changes are
+    // needed on any platform, and it works identically in dev and packaged
+    // builds. auth-server's success.ejs/error.ejs need no changes: they
+    // already just echo whatever `sid` they were given back as a redirect
+    // target, so a loopback URL works exactly like the incyclist:// one does.
+    //
+    // Trade-off accepted: unlike the embedded-window flow (which could detect
+    // the user closing the window as an explicit cancel), there is no signal
+    // when the user abandons the system-browser tab without completing or
+    // cancelling - the request just times out after AUTH_TIMEOUT_MS.
+    authorize(provider) {
+        const oauthUrl = (app.incyclistApp.settings.oauthUrl || OAUTH_SERVER).replace(/\/+$/,'')
 
-            const onStatus = (event) => {
+        return new Promise( done => {
+            let completed = false
+            let server
+            let timeoutHandle
+
+            const finish = (result) => {
+                if (completed)
+                    return
                 completed = true
-                oauth.removeAllListeners()
-                this.close(oauth) 
-                if (event.user_changed) {
-                    done( {success:true, user:event.user_changed})
+                clearTimeout(timeoutHandle)
+                if (server)
+                    server.close()
+                done(result)
+            }
+
+            server = http.createServer( (req,res) => {
+                let url
+                try {
+                    url = new URL(req.url, 'http://127.0.0.1')
                 }
-                else if (event.user_change_aborted) {
-                    done( {success:false, reason: 'user aborted'})
+                catch {
+                    res.writeHead(400); res.end(); return
                 }
-            }
 
-            const onFailed = (event) => {
-                if (completed) 
-                    return;
-                completed = true;
-                oauth.removeAllListeners()
-                this.close(oauth) 
-                done({success:false,reason: event? event.reason: undefined })                
-            }
+                if (url.pathname !== '/callback') {
+                    res.writeHead(404); res.end(); return
+                }
 
-            const onClosed = (event) => {
-                if (completed) 
-                    return;
-                completed = true;
-                oauth.removeAllListeners()
-                this.close(oauth) 
-                done({success:false,reason: 'user aborted' })                
-            }
+                res.writeHead(200,{'Content-Type':'text/html'})
+                res.end(CALLBACK_RESPONSE_HTML)
 
-            const oauth = new OAuthWindow(app.incyclistApp,{provider,legacyApi:false});
-            oauth.on('status', onStatus)
-            oauth.on('failed', onFailed )
-            oauth.on('closed', onClosed )
-            this.oauthSessions.push (oauth)    
-            
+                const params = url.searchParams
+                if (params.has('error')) {
+                    const error = params.get('error')
+                    finish({success:false, reason: error==='aborted' ? 'user aborted' : error})
+                    return
+                }
+
+                // Mirrors success.ejs, which spreads whatever fields exist on
+                // user.auth.strava/intervals into the redirect's query string -
+                // pass all of them through unchanged rather than assuming a
+                // fixed set of field names.
+                const authData = {}
+                for (const [key,value] of params.entries())
+                    authData[key] = value
+
+                finish({success:true, user:{auth:{[provider]:authData}}})
+            })
+
+            server.on('error', (err) => {
+                this.logger.logEvent({message:'local oauth callback server error', error:err.message})
+                finish({success:false, reason:'local callback server error'})
+            })
+
+            server.listen(0,'127.0.0.1', () => {
+                const port = server.address().port
+                const redirectUri = `http://127.0.0.1:${port}/callback`
+                const authUrl = `${oauthUrl}/${provider}?sid=${encodeURIComponent(redirectUri)}`
+
+                this.logger.logEvent({message:'opening system browser for oauth', provider, port})
+                shell.openExternal(authUrl).catch( (err) => {
+                    finish({success:false, reason: 'could not open browser: '+err.message})
+                })
+            })
+
+            timeoutHandle = setTimeout( () => {
+                this.logger.logEvent({message:'oauth timed out', provider})
+                finish({success:false, reason:'timeout'})
+            }, AUTH_TIMEOUT_MS)
         })
-        
     }
 
     close(session) {

--- a/src/features/oauth/feature.js
+++ b/src/features/oauth/feature.js
@@ -12,6 +12,18 @@ const AUTH_TIMEOUT_MS = 5*60*1000; // give the user enough time to log in + solv
 
 const CALLBACK_RESPONSE_HTML = '<html><body>You can close this window and return to Incyclist.</body></html>';
 
+// Avoids a regex (e.g. /\/+$/) here: a quantified-then-anchored pattern like
+// that has quadratic worst-case backtracking (SonarQube flagged this).
+// oauthUrl is a local setting, not attacker input, so the practical risk is
+// close to none - but a single linear scan is just as simple and provably
+// avoids the class of issue entirely.
+function trimTrailingSlashes(value) {
+    let end = value.length
+    while (end > 0 && value[end-1] === '/')
+        end--
+    return value.slice(0, end)
+}
+
 class OauthFeature extends Feature{
 
     static _instance;
@@ -58,7 +70,7 @@ class OauthFeature extends Feature{
     // when the user abandons the system-browser tab without completing or
     // cancelling - the request just times out after AUTH_TIMEOUT_MS.
     authorize(provider) {
-        const oauthUrl = (app.incyclistApp.settings.oauthUrl || OAUTH_SERVER).replace(/\/+$/,'')
+        const oauthUrl = trimTrailingSlashes(app.incyclistApp.settings.oauthUrl || OAUTH_SERVER)
 
         const codeVerifier = crypto.randomBytes(32).toString('base64url')
         const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url')

--- a/src/features/oauth/feature.test.js
+++ b/src/features/oauth/feature.test.js
@@ -1,0 +1,166 @@
+/**
+ * Behaviour tests for OauthFeature.authorize()
+ *
+ * Strategy
+ * --------
+ * - Use the REAL `http` module - a genuine loopback server is fast/reliable
+ *   in a test environment and lets these tests exercise the exact request
+ *   parsing logic the browser redirect would trigger, rather than mocking it
+ *   away.
+ * - Mock only the Electron boundary (`shell.openExternal`, `app.incyclistApp`)
+ *   and `ipcMain`/../utils (unused here but required by the module).
+ */
+
+jest.mock('electron', () => ({
+    ipcMain: { handle: jest.fn(), on: jest.fn() },
+    app: { incyclistApp: { settings: { oauthUrl: 'https://auth.test.local/' } } },
+    shell: { openExternal: jest.fn().mockResolvedValue(undefined) },
+}))
+jest.mock('../utils', () => ({ ipcCall: jest.fn(), ipcHandle: jest.fn(), ipcCallNoResponse: jest.fn(), ipcHandleNoResponse: jest.fn() }))
+
+const http = require('node:http')
+const { shell } = require('electron')
+const OauthFeature = require('./feature')
+
+/** Simulates the browser navigating to the callback URL success.ejs/error.ejs redirects to. */
+const hitCallback = (port, query = '') => new Promise( (resolve,reject) => {
+    http.get(`http://127.0.0.1:${port}/callback${query}`, { agent:false }, (res) => {
+        res.resume()
+        res.on('end', () => resolve(res.statusCode))
+    }).on('error', reject)
+})
+
+/** Extracts the redirect_uri (sid) the feature registered with auth-server, from the URL passed to shell.openExternal. */
+const getCallbackOrigin = () => {
+    const openedUrl = new URL(shell.openExternal.mock.calls[0][0])
+    return new URL(openedUrl.searchParams.get('sid'))
+}
+
+describe('OauthFeature.authorize()', () => {
+
+    let feature
+
+    beforeEach(() => {
+        OauthFeature._instance = undefined
+        feature = new OauthFeature()
+        jest.clearAllMocks()
+        shell.openExternal.mockResolvedValue(undefined)
+    })
+
+    test('opens the system browser at <oauthUrl>/<provider>?sid=<loopback redirect_uri>', async () => {
+        const promise = feature.authorize('strava')
+
+        // let server.listen()'s callback (which calls shell.openExternal) run
+        await new Promise(process.nextTick)
+
+        expect(shell.openExternal).toHaveBeenCalledTimes(1)
+        const openedUrl = new URL(shell.openExternal.mock.calls[0][0])
+        expect(openedUrl.origin+openedUrl.pathname).toBe('https://auth.test.local/strava')
+
+        const sid = new URL(openedUrl.searchParams.get('sid'))
+        expect(sid.hostname).toBe('127.0.0.1')
+        expect(sid.pathname).toBe('/callback')
+
+        await hitCallback(Number(sid.port), '?error=aborted')
+        await promise
+    })
+
+    test('resolves success with all callback query params passed through under user.auth.<provider>', async () => {
+        const promise = feature.authorize('strava')
+        await new Promise(process.nextTick)
+        const sid = getCallbackOrigin()
+
+        await hitCallback(Number(sid.port), '?accesstoken=tok123&refreshtoken=ref456&id=789')
+
+        await expect(promise).resolves.toEqual({
+            success: true,
+            user: { auth: { strava: { accesstoken: 'tok123', refreshtoken: 'ref456', id: '789' } } }
+        })
+    })
+
+    test('uses the provider passed to authorize() as the key under user.auth', async () => {
+        const promise = feature.authorize('intervals')
+        await new Promise(process.nextTick)
+        const sid = getCallbackOrigin()
+
+        await hitCallback(Number(sid.port), '?accesstoken=tok')
+
+        const result = await promise
+        expect(result.user.auth).toHaveProperty('intervals')
+        expect(result.user.auth).not.toHaveProperty('strava')
+    })
+
+    test('resolves { success:false, reason:"user aborted" } for ?error=aborted (mirrors error.ejs)', async () => {
+        const promise = feature.authorize('strava')
+        await new Promise(process.nextTick)
+        const sid = getCallbackOrigin()
+
+        await hitCallback(Number(sid.port), '?error=aborted')
+
+        await expect(promise).resolves.toEqual({ success:false, reason:'user aborted' })
+    })
+
+    test('passes through a non-"aborted" error value from the callback as-is', async () => {
+        const promise = feature.authorize('strava')
+        await new Promise(process.nextTick)
+        const sid = getCallbackOrigin()
+
+        await hitCallback(Number(sid.port), '?error=access_denied')
+
+        await expect(promise).resolves.toEqual({ success:false, reason:'access_denied' })
+    })
+
+    test('a request to any path other than /callback is ignored and does not resolve the promise', async () => {
+        const promise = feature.authorize('strava')
+        await new Promise(process.nextTick)
+        const sid = getCallbackOrigin()
+
+        const stray = await new Promise( (resolve,reject) => {
+            http.get(`http://127.0.0.1:${sid.port}/favicon.ico`, { agent:false }, (res) => { res.resume(); res.on('end', () => resolve(res.statusCode)) }).on('error',reject)
+        })
+        expect(stray).toBe(404)
+
+        // the real callback still resolves the same pending promise afterwards
+        await hitCallback(sid.port, '?accesstoken=tok')
+        await expect(promise).resolves.toMatchObject({ success:true })
+    })
+
+    test('the loopback server stops listening once the flow completes', async () => {
+        const createSpy = jest.spyOn(http, 'createServer')
+        const promise = feature.authorize('strava')
+        await new Promise(process.nextTick)
+        const sid = getCallbackOrigin()
+        const server = createSpy.mock.results[0].value
+
+        await hitCallback(Number(sid.port), '?accesstoken=tok')
+        await promise
+
+        expect(server.listening).toBe(false)
+        createSpy.mockRestore()
+    })
+
+    test('resolves { success:false } when shell.openExternal fails to open a browser', async () => {
+        shell.openExternal.mockRejectedValue(new Error('no browser configured'))
+
+        const result = await feature.authorize('strava')
+
+        expect(result.success).toBe(false)
+        expect(result.reason).toMatch(/no browser configured/)
+    })
+
+    test('times out and resolves { success:false, reason:"timeout" } if nothing ever hits the callback', async () => {
+        jest.useFakeTimers()
+        try {
+            const promise = feature.authorize('strava')
+            await Promise.resolve() // let server.listen() schedule shell.openExternal
+
+            jest.advanceTimersByTime(5*60*1000 + 1)
+
+            await expect(promise).resolves.toEqual({ success:false, reason:'timeout' })
+        }
+        finally {
+            jest.useRealTimers()
+        }
+    })
+
+})

--- a/src/features/oauth/feature.test.js
+++ b/src/features/oauth/feature.test.js
@@ -7,8 +7,9 @@
  *   in a test environment and lets these tests exercise the exact request
  *   parsing logic the browser redirect would trigger, rather than mocking it
  *   away.
- * - Mock only the Electron boundary (`shell.openExternal`, `app.incyclistApp`)
- *   and `ipcMain`/../utils (unused here but required by the module).
+ * - Mock only the Electron boundary (`shell.openExternal`, `app.incyclistApp`),
+ *   `axios` (the off-browser code-exchange call to auth-server) and
+ *   `ipcMain`/../utils (unused here but required by the module).
  */
 
 jest.mock('electron', () => ({
@@ -17,8 +18,11 @@ jest.mock('electron', () => ({
     shell: { openExternal: jest.fn().mockResolvedValue(undefined) },
 }))
 jest.mock('../utils', () => ({ ipcCall: jest.fn(), ipcHandle: jest.fn(), ipcCallNoResponse: jest.fn(), ipcHandleNoResponse: jest.fn() }))
+jest.mock('axios')
 
 const http = require('node:http')
+const crypto = require('node:crypto')
+const axios = require('axios')
 const { shell } = require('electron')
 const OauthFeature = require('./feature')
 
@@ -30,11 +34,12 @@ const hitCallback = (port, query = '') => new Promise( (resolve,reject) => {
     }).on('error', reject)
 })
 
-/** Extracts the redirect_uri (sid) the feature registered with auth-server, from the URL passed to shell.openExternal. */
-const getCallbackOrigin = () => {
-    const openedUrl = new URL(shell.openExternal.mock.calls[0][0])
-    return new URL(openedUrl.searchParams.get('sid'))
-}
+/** Parses the URL the feature opened via shell.openExternal. */
+const getOpenedUrl = () => new URL(shell.openExternal.mock.calls[0][0])
+
+const getCallbackOrigin = () => new URL(getOpenedUrl().searchParams.get('sid'))
+
+const sha256base64url = (value) => crypto.createHash('sha256').update(value).digest('base64url')
 
 describe('OauthFeature.authorize()', () => {
 
@@ -45,17 +50,20 @@ describe('OauthFeature.authorize()', () => {
         feature = new OauthFeature()
         jest.clearAllMocks()
         shell.openExternal.mockResolvedValue(undefined)
+        axios.post.mockResolvedValue({ data: { user: { auth: { strava: { accesstoken:'tok' } } } } })
     })
 
-    test('opens the system browser at <oauthUrl>/<provider>?sid=<loopback redirect_uri>', async () => {
+    test('opens the system browser at <oauthUrl>/<provider>?sid=<loopback redirect_uri>&code_challenge=...', async () => {
         const promise = feature.authorize('strava')
 
         // let server.listen()'s callback (which calls shell.openExternal) run
         await new Promise(process.nextTick)
 
         expect(shell.openExternal).toHaveBeenCalledTimes(1)
-        const openedUrl = new URL(shell.openExternal.mock.calls[0][0])
+        const openedUrl = getOpenedUrl()
         expect(openedUrl.origin+openedUrl.pathname).toBe('https://auth.test.local/strava')
+        expect(openedUrl.searchParams.get('code_challenge_method')).toBe('S256')
+        expect(openedUrl.searchParams.get('code_challenge')).toBeTruthy()
 
         const sid = new URL(openedUrl.searchParams.get('sid'))
         expect(sid.hostname).toBe('127.0.0.1')
@@ -65,29 +73,61 @@ describe('OauthFeature.authorize()', () => {
         await promise
     })
 
-    test('resolves success with all callback query params passed through under user.auth.<provider>', async () => {
+    test('exchanges the callback code for tokens via a direct POST carrying the matching verifier', async () => {
+        const promise = feature.authorize('strava')
+        await new Promise(process.nextTick)
+        const openedUrl = getOpenedUrl()
+        const codeChallenge = openedUrl.searchParams.get('code_challenge')
+        const sid = getCallbackOrigin()
+
+        await hitCallback(Number(sid.port), '?code=abc123')
+        await promise
+
+        expect(axios.post).toHaveBeenCalledTimes(1)
+        const [url, body] = axios.post.mock.calls[0]
+        expect(url).toBe('https://auth.test.local/strava/token')
+        expect(body.code).toBe('abc123')
+        // the verifier sent to auth-server must be the pre-image of the
+        // code_challenge that was published in the (attacker-visible) browser URL
+        expect(sha256base64url(body.code_verifier)).toBe(codeChallenge)
+    })
+
+    test('resolves { success:true, user } from the token-exchange response body', async () => {
+        axios.post.mockResolvedValue({ data: { user: { auth: { strava: { accesstoken:'tok123', refreshtoken:'ref456', id:'789' } } } } })
+
         const promise = feature.authorize('strava')
         await new Promise(process.nextTick)
         const sid = getCallbackOrigin()
 
-        await hitCallback(Number(sid.port), '?accesstoken=tok123&refreshtoken=ref456&id=789')
+        await hitCallback(Number(sid.port), '?code=abc123')
 
         await expect(promise).resolves.toEqual({
             success: true,
-            user: { auth: { strava: { accesstoken: 'tok123', refreshtoken: 'ref456', id: '789' } } }
+            user: { auth: { strava: { accesstoken:'tok123', refreshtoken:'ref456', id:'789' } } }
         })
     })
 
-    test('uses the provider passed to authorize() as the key under user.auth', async () => {
-        const promise = feature.authorize('intervals')
+    test('resolves { success:false } when the code exchange POST fails (e.g. wrong/expired code)', async () => {
+        axios.post.mockRejectedValue({ response: { status: 400, data: { error:'invalid_grant' } } })
+
+        const promise = feature.authorize('strava')
         await new Promise(process.nextTick)
         const sid = getCallbackOrigin()
 
-        await hitCallback(Number(sid.port), '?accesstoken=tok')
+        await hitCallback(Number(sid.port), '?code=stale-code')
 
-        const result = await promise
-        expect(result.user.auth).toHaveProperty('intervals')
-        expect(result.user.auth).not.toHaveProperty('strava')
+        await expect(promise).resolves.toMatchObject({ success:false })
+    })
+
+    test('resolves { success:false, reason:"no code in callback" } if the callback carries neither code nor error', async () => {
+        const promise = feature.authorize('strava')
+        await new Promise(process.nextTick)
+        const sid = getCallbackOrigin()
+
+        await hitCallback(Number(sid.port), '')
+
+        await expect(promise).resolves.toEqual({ success:false, reason:'no code in callback' })
+        expect(axios.post).not.toHaveBeenCalled()
     })
 
     test('resolves { success:false, reason:"user aborted" } for ?error=aborted (mirrors error.ejs)', async () => {
@@ -98,6 +138,7 @@ describe('OauthFeature.authorize()', () => {
         await hitCallback(Number(sid.port), '?error=aborted')
 
         await expect(promise).resolves.toEqual({ success:false, reason:'user aborted' })
+        expect(axios.post).not.toHaveBeenCalled()
     })
 
     test('passes through a non-"aborted" error value from the callback as-is', async () => {
@@ -121,7 +162,7 @@ describe('OauthFeature.authorize()', () => {
         expect(stray).toBe(404)
 
         // the real callback still resolves the same pending promise afterwards
-        await hitCallback(sid.port, '?accesstoken=tok')
+        await hitCallback(sid.port, '?code=abc123')
         await expect(promise).resolves.toMatchObject({ success:true })
     })
 
@@ -132,7 +173,7 @@ describe('OauthFeature.authorize()', () => {
         const sid = getCallbackOrigin()
         const server = createSpy.mock.results[0].value
 
-        await hitCallback(Number(sid.port), '?accesstoken=tok')
+        await hitCallback(Number(sid.port), '?code=abc123')
         await promise
 
         expect(server.listening).toBe(false)


### PR DESCRIPTION
## Summary

Fixes #97. `OauthFeature.authorize()` (Settings → App → Strava/Intervals "Connect", the `oauth-authorize` IPC path) rendered the provider's real login page inside an embedded Electron `BrowserWindow` (`OAuthWindow`). Even after hardening that window in #200 (`nodeIntegration:false`/`contextIsolation:true`, dropping a spoofed `Chrome/107` User-Agent), a live Strava connect attempt still failed with a generic "unexpected error" — traced via the Network tab to a `403` on Strava's `request_otp` endpoint, immediately after their reCAPTCHA Enterprise challenge runs.

This matches a known, previously-unresolved report in #97: on Linux specifically, Strava's CAPTCHA library intermittently fails to execute correctly inside the embedded Chromium instance, and the only known workaround so far was launching with `DEBUG=true` (which happens to force DevTools open).

## What changed

`OauthFeature.authorize()` now opens the provider's login page in the user's real, already-trusted **default system browser** (`shell.openExternal`) instead of an embedded window — the same architectural pattern `mobile` already uses. Since it's a real, unmodified browser, there's no embedded-Chromium quirk left to trip over. The legacy embedded-window path (`OAuthWindow`, `oauth-show` IPC) is untouched — this only changes the current, active `authorize()`/`oauth-authorize` path.

The callback comes back via a short-lived **loopback HTTP server** on an ephemeral port (`http://127.0.0.1:<port>/callback`) rather than a custom URL scheme, so there's **no OS-level protocol registration or packaging changes** needed on any platform.

## Security iteration (this went through a few rounds — documenting for reviewers)

1. **Companion `auth-server` fix required:** `success.ejs`/`error.ejs` only redirected the browser back for a `sid` starting with `incyclist://` (mobile's scheme) — a loopback `sid` matched nothing and stranded the browser on the confirmation page. Fixed in [incyclist/microservices#133](https://github.com/incyclist/microservices/pull/133).
2. **Open redirect:** the first fix for (1) generalized the redirect to *any* `sid` — since `sid` is attacker-controlled, this was an open redirect that could send a real user's tokens to an arbitrary URL. Fixed with an allowlist (`incyclist://` or `http://127.0.0.1:<port>`, validated via real `URL` parsing to avoid userinfo-prefix bypass tricks).
3. **PKCE (current state):** even with the allowlist, real tokens were still placed directly in the loopback redirect's query string — reachable by *any* local process willing to bind a port, not just this app. A malicious local process could construct its own competing `sid`/port and receive real tokens if the user clicked through Strava's legitimate-looking consent screen. `authorize()` now generates a random PKCE verifier that never leaves this process, sends only its SHA-256 hash in the browser URL, and the loopback redirect now carries a short-lived, single-use exchange code instead of tokens. The real tokens are only obtained via a direct, off-browser HTTPS `POST` to `<oauthUrl>/<provider>/token` with that code + the verifier.

**What PKCE does and doesn't close** (worth reviewers knowing explicitly): it closes a malicious local listener intercepting *this flow's* tokens. It does **not** — and structurally cannot, for an open-source native client — prevent a malicious local process from running its **own**, independently-constructed OAuth flow and phishing the user into clicking through a legitimate Strava consent screen for it; no client-side mechanism can distinguish "the real app" from "a local script that read the same open-source code." This is the same accepted residual risk every native OAuth client using this pattern (gcloud, VS Code, ...) lives with.

**This PR depends on microservices#133 being deployed** for the flow to complete end-to-end.

## Trade-off (accepted, called out here)

Unlike the embedded window, which could detect the user closing it as an explicit cancel, there's no signal if the user abandons the system browser tab without completing the flow — it just times out after 5 minutes.

## Test plan

- [x] `npm test` — 23 suites / 331 tests pass, including `src/features/oauth/feature.test.js` (11 tests): browser-open URL shape (incl. `code_challenge`), code-exchange POST carries the correct verifier (SHA-256 pre-image of the published challenge), success/failure of the exchange, missing-code handling, both error shapes, stray-request handling, loopback server cleanup, `shell.openExternal` failure, timeout.
- [x] Verified live end-to-end (pre-PKCE version, with #133's allowlist fix applied ahead of deploy): Strava connect flow completes, browser redirects to the local loopback confirmation page, app receives the credentials.
- [x] **Re-verified with the PKCE revision against prod** — confirmed working end-to-end by the user after microservices#133 rolled out.
- [x] Smoke-test the intervals.icu connect flow too, for no regression there.