### PR TITLE
fix: Mac pkg build broke on the Aug 2026 macos-26-arm64 runner image bump

### DIFF
--- a/config/forge.config.darwin.incyclist.js
+++ b/config/forge.config.darwin.incyclist.js
@@ -20,16 +20,26 @@ const INSTALL_LOCATION = '/Applications'
 // BundleIsRelocatable forced off.
 async function buildNonRelocatablePkg(appPath, pkgPath, identity) {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'incyclist-pkg-'))
+  const rootPath = path.join(tmpDir, 'root')
   const componentPlistPath = path.join(tmpDir, 'component.plist')
   const componentPkgPath = path.join(tmpDir, `${APP_NAME}-component.pkg`)
 
   try {
-    await execFileAsync('pkgbuild', ['--analyze', '--component', appPath, componentPlistPath])
+    // --component-plist / BundleIsRelocatable only take effect in pkgbuild's
+    // --root mode - --component (single-bundle) mode has no way to override
+    // the generated component plist. So the payload root mirrors the actual
+    // install location (root/Incyclist.app), populated with a real copy of
+    // the already packaged, signed .app - pkgbuild's symlink handling in
+    // --root mode isn't documented, so this avoids relying on it.
+    await fs.mkdir(rootPath, { recursive: true })
+    await fs.cp(appPath, path.join(rootPath, `${APP_NAME}.app`), { recursive: true, verbatimSymlinks: true })
+
+    await execFileAsync('pkgbuild', ['--analyze', '--root', rootPath, componentPlistPath])
     await execFileAsync('/usr/libexec/PlistBuddy', ['-c', 'Set :0:BundleIsRelocatable false', componentPlistPath])
 
     await execFileAsync('pkgbuild', [
+      '--root', rootPath,
       '--install-location', INSTALL_LOCATION,
-      '--component', appPath,
       '--component-plist', componentPlistPath,
       componentPkgPath,
     ])


### PR DESCRIPTION
## Summary
- The signed Mac build (`postPackage` hook in `config/forge.config.darwin.incyclist.js`, added via #189) started failing on real CI after the `macos-26-arm64` GitHub runner image was bumped from `20260715.0248.1` (macOS 26.4) to `20260728.0273.1` (macOS 26.5.2) between July 17 and today. Confirmed via the two Mac Build runs on `main`: [signed run, fails](https://github.com/incyclist/desktop/actions/runs/31045802201) with `pkgbuild: error: --root must be specified in --analyze mode.`
- Root cause per Apple's `pkgbuild(1)` docs: `--analyze` has always required `--root` and is documented as mutually exclusive with `--component`. The old runner's `pkgbuild` apparently tolerated `--component` there; the newer one enforces the documented contract and rejects it outright.
- A second, previously-undetected issue this exposed: the real (non-analyze) `pkgbuild` call two lines later combined `--component` with `--component-plist` — but `--component-plist` is only ever documented in the context of `--root` mode, so the whole point of that hand-rolled step (forcing `BundleIsRelocatable` off, to fix the installer-relocation bug from an earlier commit) was likely a no-op even before this crash.

## What changed
`config/forge.config.darwin.incyclist.js` — `buildNonRelocatablePkg` now builds a real payload root (`root/Incyclist.app`, a full copy of the already-signed `.app` — not a symlink, since pkgbuild's symlink-following behavior in `--root` mode isn't documented) and uses `--root` consistently for both the `--analyze` step and the actual package-build step, instead of `--component`.

## Test plan
- [x] `npm test` — 332/332 passing
- [x] Signed Mac build (`sign_mac=true` workflow_dispatch on this branch) — verifying now