### PR TITLE
fix: retry, surface, and prioritize WebBLE device discovery failures

### DIFF
--- a/src/features/webble/device-cache.js
+++ b/src/features/webble/device-cache.js
@@ -1,0 +1,120 @@
+const fs = require('fs')
+const path = require('path')
+const { getAppDirectory } = require('../../utils')
+const { EventLogger } = require('gd-eventlog')
+
+const FILE_NAME = 'webble-devices.json'
+
+// consecutive probe failures (for a device never explicitly connected to) before
+// it's written off as "bad" and excluded from the chooser for good
+const BAD_THRESHOLD = 3
+
+/**
+ * Persists BLE device reputation (by MAC) across app launches, so a device the
+ * user already uses (e.g. their trainer) is preferred from the very first scan of
+ * a new session, and a device that never connects (e.g. a nearby speaker) stops
+ * being offered at all — instead of both re-learning this from scratch, in-memory
+ * only, every single launch.
+ *
+ * Session-local "this device just failed, try it again later" tracking stays in
+ * feature.js's probeCooldowns — that's inherently transient and doesn't need to
+ * survive a restart.
+ */
+class WebBleDeviceCache {
+    static _instance
+
+    static getInstance() {
+        if (!WebBleDeviceCache._instance)
+            WebBleDeviceCache._instance = new WebBleDeviceCache()
+        return WebBleDeviceCache._instance
+    }
+
+    constructor() {
+        this.logger = new EventLogger('WebBLE')
+        this.entries = {}   // mac → { name, status: 'good'|'bad', failCount }
+        this._load()
+    }
+
+    _filePath() {
+        return path.join(getAppDirectory(), FILE_NAME)
+    }
+
+    _load() {
+        try {
+            const file = this._filePath()
+            if (fs.existsSync(file))
+                this.entries = JSON.parse(fs.readFileSync(file, 'utf8'))
+        } catch (err) {
+            this.logger.logEvent({ message: 'could not load webble device cache', error: err.message })
+            this.entries = {}
+        }
+    }
+
+    _save() {
+        try {
+            fs.writeFileSync(this._filePath(), JSON.stringify(this.entries, null, 2), { encoding: 'utf8' })
+        } catch (err) {
+            this.logger.logEvent({ message: 'could not save webble device cache', error: err.message })
+        }
+    }
+
+    isGood(mac) {
+        return this.entries[mac]?.status === 'good'
+    }
+
+    isBad(mac) {
+        return this.entries[mac]?.status === 'bad'
+    }
+
+    /**
+     * Immediate blacklist — used when we have a definitive signal (a device whose
+     * full GATT service list shares nothing with our fitness services), not just a
+     * connection hiccup. The connection succeeded; we know for certain it's the
+     * wrong kind of device, so there's no reason to wait for repeated misses like
+     * recordFailure() does. Still never downgrades an explicitly-wanted device.
+     */
+    markBad(mac, name) {
+        if (!mac || this.isGood(mac)) return
+        this.entries[mac] = { name, status: 'bad', failCount: this.entries[mac]?.failCount ?? BAD_THRESHOLD }
+        this.logger.logEvent({ message: 'webble device cache: marked bad (unsupported device type)', deviceId: mac, name })
+        this._save()
+    }
+
+    /**
+     * Every MAC ever explicitly connected to — persisted so it's preferred by the
+     * chooser from the very first scan of a later launch. Deliberately doesn't
+     * remember service lists: some devices (e.g. a rower whose FTMS service only
+     * appears once its GATT server has fully initialised) advertise a different,
+     * incomplete service set depending on exactly when they're probed — reusing a
+     * stale snapshot across launches could permanently hide a capability the
+     * device actually has. Every discovery still gets a live probe; only the
+     * ordering (who gets tried first) is influenced by this cache.
+     */
+    markGood(mac, name) {
+        if (!mac || this.isGood(mac)) return
+        this.entries[mac] = { name, status: 'good', failCount: 0 }
+        this.logger.logEvent({ message: 'webble device cache: marked good', deviceId: mac, name })
+        this._save()
+    }
+
+    /**
+     * Records a probe failure. A device we've ever explicitly wanted (already
+     * "good") is never downgraded, however flaky it is right now — that's what
+     * the session-local cooldown/parking is for instead.
+     */
+    recordFailure(mac, name) {
+        if (!mac || this.isGood(mac)) return
+
+        const entry = this.entries[mac] ?? { name, status: undefined, failCount: 0 }
+        entry.name = name ?? entry.name
+        entry.failCount = (entry.failCount ?? 0) + 1
+        if (entry.failCount >= BAD_THRESHOLD) entry.status = 'bad'
+        this.entries[mac] = entry
+
+        if (entry.status === 'bad')
+            this.logger.logEvent({ message: 'webble device cache: marked bad', deviceId: mac, name: entry.name, failCount: entry.failCount })
+        this._save()
+    }
+}
+
+module.exports = WebBleDeviceCache

--- a/src/features/webble/device-cache.js
+++ b/src/features/webble/device-cache.js
@@ -1,5 +1,5 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const { getAppDirectory } = require('../../utils')
 const { EventLogger } = require('gd-eventlog')
 

--- a/src/features/webble/device-cache.test.js
+++ b/src/features/webble/device-cache.test.js
@@ -1,0 +1,201 @@
+jest.mock('fs')
+jest.mock('../../utils', () => ({
+    getAppDirectory: jest.fn(() => '/fake/app/dir'),
+}))
+
+const fs = require('fs')
+const path = require('path')
+const WebBleDeviceCache = require('./device-cache')
+
+const EXPECTED_FILE = path.join('/fake/app/dir', 'webble-devices.json')
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    fs.existsSync.mockReturnValue(false)
+})
+
+describe('WebBleDeviceCache — loading', () => {
+
+    test('starts empty when no file exists', () => {
+        fs.existsSync.mockReturnValue(false)
+        const cache = new WebBleDeviceCache()
+        expect(cache.isGood('aa')).toBe(false)
+        expect(cache.isBad('aa')).toBe(false)
+    })
+
+    test('loads persisted entries from the app-data file', () => {
+        fs.existsSync.mockReturnValue(true)
+        fs.readFileSync.mockReturnValue(JSON.stringify({
+            'D4:C9:BB:7D:CB:AF': { name: 'Volt', status: 'good', failCount: 0 },
+            'AA:BB:CC:DD:EE:FF': { name: 'JBL PartyBox', status: 'bad', failCount: 3 },
+        }))
+
+        const cache = new WebBleDeviceCache()
+
+        expect(cache.isGood('D4:C9:BB:7D:CB:AF')).toBe(true)
+        expect(cache.isBad('AA:BB:CC:DD:EE:FF')).toBe(true)
+    })
+
+    test('reads from the app-data directory, not the source tree', () => {
+        fs.existsSync.mockReturnValue(true)
+        fs.readFileSync.mockReturnValue('{}')
+
+        new WebBleDeviceCache()
+
+        expect(fs.existsSync).toHaveBeenCalledWith(EXPECTED_FILE)
+        expect(fs.readFileSync).toHaveBeenCalledWith(EXPECTED_FILE, 'utf8')
+    })
+
+    test('starts empty (does not throw) when the file is corrupt', () => {
+        fs.existsSync.mockReturnValue(true)
+        fs.readFileSync.mockReturnValue('{ not valid json')
+
+        const cache = new WebBleDeviceCache()
+
+        expect(cache.isGood('aa')).toBe(false)
+        expect(cache.isBad('aa')).toBe(false)
+    })
+
+    test('starts empty (does not throw) when reading the file fails', () => {
+        fs.existsSync.mockReturnValue(true)
+        fs.readFileSync.mockImplementation(() => { throw new Error('EACCES') })
+
+        expect(() => new WebBleDeviceCache()).not.toThrow()
+    })
+
+})
+
+describe('WebBleDeviceCache — markGood', () => {
+
+    let cache
+
+    beforeEach(() => {
+        cache = new WebBleDeviceCache()
+    })
+
+    test('marks a MAC as good', () => {
+        cache.markGood('D4:C9:BB:7D:CB:AF', 'Volt')
+        expect(cache.isGood('D4:C9:BB:7D:CB:AF')).toBe(true)
+    })
+
+    test('persists to the app-data file', () => {
+        cache.markGood('D4:C9:BB:7D:CB:AF', 'Volt')
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+            EXPECTED_FILE,
+            expect.stringContaining('"D4:C9:BB:7D:CB:AF"'),
+            expect.objectContaining({ encoding: 'utf8' })
+        )
+    })
+
+    test('is a no-op without a deviceId', () => {
+        cache.markGood(undefined, 'Volt')
+        expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
+
+    test('overturns a previously-bad classification (explicit connect always wins)', () => {
+        cache.recordFailure('aa', 'Flaky')
+        cache.recordFailure('aa', 'Flaky')
+        cache.recordFailure('aa', 'Flaky')
+        expect(cache.isBad('aa')).toBe(true)
+
+        cache.markGood('aa', 'Flaky')
+
+        expect(cache.isBad('aa')).toBe(false)
+        expect(cache.isGood('aa')).toBe(true)
+    })
+
+    test('does not re-save when already good (no-op on repeat calls)', () => {
+        cache.markGood('D4:C9:BB:7D:CB:AF', 'Volt')
+        fs.writeFileSync.mockClear()
+
+        cache.markGood('D4:C9:BB:7D:CB:AF', 'Volt')
+
+        expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
+
+})
+
+describe('WebBleDeviceCache — markBad', () => {
+
+    let cache
+
+    beforeEach(() => {
+        cache = new WebBleDeviceCache()
+    })
+
+    test('blacklists immediately, without needing repeated failures', () => {
+        cache.markBad('aa', 'JBL PartyBox')
+        expect(cache.isBad('aa')).toBe(true)
+    })
+
+    test('persists to the app-data file', () => {
+        cache.markBad('aa', 'JBL PartyBox')
+        expect(fs.writeFileSync).toHaveBeenCalled()
+    })
+
+    test('is a no-op without a deviceId', () => {
+        cache.markBad(undefined, 'JBL PartyBox')
+        expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
+
+    test('never downgrades an already-good device', () => {
+        cache.markGood('aa', 'Volt')
+        cache.markBad('aa', 'Volt')
+        expect(cache.isGood('aa')).toBe(true)
+        expect(cache.isBad('aa')).toBe(false)
+    })
+
+})
+
+describe('WebBleDeviceCache — recordFailure', () => {
+
+    let cache
+
+    beforeEach(() => {
+        cache = new WebBleDeviceCache()
+    })
+
+    test('does not blacklist below the failure threshold', () => {
+        cache.recordFailure('aa', 'JBL PartyBox')
+        cache.recordFailure('aa', 'JBL PartyBox')
+        expect(cache.isBad('aa')).toBe(false)
+    })
+
+    test('blacklists after repeated failures', () => {
+        cache.recordFailure('aa', 'JBL PartyBox')
+        cache.recordFailure('aa', 'JBL PartyBox')
+        cache.recordFailure('aa', 'JBL PartyBox')
+        expect(cache.isBad('aa')).toBe(true)
+    })
+
+    test('never downgrades a device that is already good, however often it fails', () => {
+        cache.markGood('aa', 'Volt')
+        cache.recordFailure('aa', 'Volt')
+        cache.recordFailure('aa', 'Volt')
+        cache.recordFailure('aa', 'Volt')
+        cache.recordFailure('aa', 'Volt')
+        expect(cache.isGood('aa')).toBe(true)
+        expect(cache.isBad('aa')).toBe(false)
+    })
+
+    test('is a no-op without a deviceId', () => {
+        expect(() => cache.recordFailure(undefined, 'x')).not.toThrow()
+    })
+
+    test('persists to the app-data file', () => {
+        cache.recordFailure('aa', 'JBL PartyBox')
+        expect(fs.writeFileSync).toHaveBeenCalled()
+    })
+
+})
+
+describe('WebBleDeviceCache — getInstance', () => {
+
+    test('returns the same instance across calls', () => {
+        WebBleDeviceCache._instance = undefined
+        const a = WebBleDeviceCache.getInstance()
+        const b = WebBleDeviceCache.getInstance()
+        expect(a).toBe(b)
+    })
+
+})

--- a/src/features/webble/feature.js
+++ b/src/features/webble/feature.js
@@ -1,10 +1,17 @@
 const { app, ipcMain } = require('electron')
-const { ipcHandleNoResponse, ipcHandleSync, ipcCallSync } = require('../utils')
+const { ipcHandleNoResponse, ipcHandleSync, ipcCallSync, ipcCallNoResponse } = require('../utils')
 const Feature = require('../base')
 const WebBleIpcBinding = require('./ipc-binding')
+const WebBleDeviceCache = require('./device-cache')
 const { EventLogger } = require('gd-eventlog')
 
 const CONNECT_TARGET_TIMEOUT = 30 * 1000
+
+// how long a device that just failed its GATT probe is skipped for, so it doesn't
+// keep re-winning the chooser's next slot at the expense of other devices (e.g. a
+// nearby non-fitness BLE device that will never connect). Devices we've explicitly
+// asked to connect to (connectTargetMacs) are exempt — see _inCooldown().
+const PROBE_FAILURE_COOLDOWN = 60 * 1000
 
 // linux has no native BLE binding, so WebBLE is its only option. win32 has WinrtBindings
 // as the default and stable path — WebBLE is announced there too so web-ui can opt
@@ -18,6 +25,7 @@ class WebBleFeature extends Feature {
     constructor() {
         super()
         this.logger = new EventLogger('WebBLE')
+        this.deviceCache = WebBleDeviceCache.getInstance()
 
         // Scanning and connecting are independent: a connect request must never
         // stop the request loop, otherwise no further devices get discovered.
@@ -37,6 +45,17 @@ class WebBleFeature extends Feature {
         // approved per requestDevice call, so this maps 1:1 to the device object
         // that requestDevice resolves with — consumed via takeApproved().
         this.lastApproved = null             // { deviceId, deviceName }
+
+        // MACs ever explicitly requested via connect() (i.e. a device the app already
+        // knows about and specifically wants) — these never get cooled down, however
+        // often their probe fails. Deliberately never reset by startScan(): unlike
+        // discoveredDeviceIds, "this is a device we care about" doesn't expire per scan.
+        this.connectTargetMacs = new Set()
+        // deviceId → cooldown-expiry timestamp. Skips a device that just failed its
+        // GATT probe so it doesn't keep re-winning the chooser's next slot at the
+        // expense of other devices. Also not reset by startScan() — that reset is
+        // exactly what let a persistently-failing device win every fresh scan cycle.
+        this.probeCooldowns = new Map()
 
         this._scanLoopTimeout = null
         this._iterationInFlight = false
@@ -63,6 +82,76 @@ class WebBleFeature extends Feature {
 
     _shouldLoop() {
         return this.scanning || this._hasConnectTarget()
+    }
+
+    /**
+     * A device we explicitly asked to connect to — this session (connectTargetMacs)
+     * or a previous one (persisted device cache) — is never in cooldown. For anything
+     * else, an unexpired cooldown entry (set via reportProbeFailed) excludes it from
+     * the next chooser slot.
+     */
+    _inCooldown(deviceId) {
+        if (this.connectTargetMacs.has(deviceId) || this.deviceCache.isGood(deviceId)) return false
+        const expires = this.probeCooldowns.get(deviceId)
+        if (!expires) return false
+        if (Date.now() > expires) {
+            this.probeCooldowns.delete(deviceId)
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Relays a log event from the renderer (ipc-binding.js). The renderer can't use
+     * gd-eventlog directly for this: it's loaded via the preload's own require() graph,
+     * a different module instance than the one web-ui's bundle registers adapters on —
+     * so a renderer-local EventLogger would silently have no adapters. Routing through
+     * here reuses this (main-process) logger, which already has them.
+     */
+    log(event) {
+        this.logger.logEvent(event)
+    }
+
+    /**
+     * Called (via IPC) by the renderer when a device's GATT probe fails after
+     * retries. Devices we explicitly requested via connect() are exempt — we want
+     * those retried as eagerly as possible, not deprioritized. Anything else is
+     * also recorded in the persisted device cache — repeated failures across
+     * sessions eventually blacklist a device outright (see device-cache.js).
+     */
+    reportProbeFailed(deviceId, deviceName) {
+        if (this.connectTargetMacs.has(deviceId)) {
+            this.logger.logEvent({ message: 'probe failed, retrying eagerly (explicitly requested device)', deviceId })
+            return
+        }
+        this.probeCooldowns.set(deviceId, Date.now() + PROBE_FAILURE_COOLDOWN)
+        this.logger.logEvent({ message: 'probe failed, entering cooldown', deviceId, cooldownMs: PROBE_FAILURE_COOLDOWN })
+        this.deviceCache.recordFailure(deviceId, deviceName)
+    }
+
+    /**
+     * Called (via IPC) when a device's full GATT service list — successfully read,
+     * unlike a probe failure — shares nothing with our known fitness services. A
+     * stronger, immediate signal than reportProbeFailed: the connection worked, so
+     * this isn't a fluke, it's confirmed to be the wrong kind of device. Blacklists
+     * outright instead of waiting for repeated misses.
+     */
+    reportUnsupportedDevice(deviceId, deviceName) {
+        if (this.connectTargetMacs.has(deviceId)) return
+        this.deviceCache.markBad(deviceId, deviceName)
+        this.logger.logEvent({ message: 'device confirmed unsupported', deviceId, deviceName })
+    }
+
+    /**
+     * Called (via IPC) by the renderer when a GATT connect actually succeeds — the
+     * reliable "this MAC is a device we use" signal. This is deliberately separate
+     * from connect(): that fires only on its 'approval' fallback source, which in a
+     * normal session (device already found by the scan loop) is rarely reached.
+     */
+    reportConnectSucceeded(deviceId, deviceName) {
+        this.connectTargetMacs.add(deviceId)
+        this.deviceCache.markGood(deviceId, deviceName)
+        this.logger.logEvent({ message: 'connect succeeded', deviceId, deviceName })
     }
 
     _approve(device, callback) {
@@ -116,10 +205,23 @@ class WebBleFeature extends Feature {
         }
 
         if (this.scanning) {
-            // Only named devices get approved. When nothing usable is new, the
-            // callback is parked below — the event re-fires on device list changes.
-            const newDevice = deviceList.find(d =>
-                !this.discoveredDeviceIds.has(d.deviceId) && this._isUsableName(d.deviceName))
+            // Devices known to never work (persisted, repeated failures) are
+            // excluded outright — not even as a last resort.
+            const candidates = deviceList.filter(d =>
+                !this.discoveredDeviceIds.has(d.deviceId) &&
+                this._isUsableName(d.deviceName) &&
+                !this.deviceCache.isBad(d.deviceId))
+
+            // tier 1: a device we already know we want (this session or a previous
+            // one) always wins, regardless of chooser order or cooldown.
+            let newDevice = candidates.find(d =>
+                this.connectTargetMacs.has(d.deviceId) || this.deviceCache.isGood(d.deviceId))
+            // tier 2: anything not currently cooled down from a recent probe failure.
+            if (!newDevice) newDevice = candidates.find(d => !this._inCooldown(d.deviceId))
+            // tier 3: nothing better available this round — try a parked/cooled-down
+            // candidate anyway rather than leaving the chooser idle until it expires.
+            if (!newDevice) newDevice = candidates[0]
+
             if (newDevice) {
                 this._approve(newDevice, callback)
                 return
@@ -165,6 +267,8 @@ class WebBleFeature extends Feature {
 
     connect(deviceId) {
         this.logger.logEvent({ message: 'connect', deviceId })
+        this.connectTargetMacs.add(deviceId)
+        this.deviceCache.markGood(deviceId)
         this.connectTargetId = deviceId
         this.connectTargetExpires = Date.now() + CONNECT_TARGET_TIMEOUT
 
@@ -262,6 +366,10 @@ class WebBleFeature extends Feature {
         ipcHandleNoResponse('webble-disconnect', this.disconnect.bind(this), ipcMain)
         ipcHandleSync('webble-get-mac', this.getMac.bind(this), ipcMain)
         ipcHandleSync('webble-take-approved', this.takeApproved.bind(this), ipcMain)
+        ipcHandleNoResponse('webble-probe-failed', this.reportProbeFailed.bind(this), ipcMain)
+        ipcHandleNoResponse('webble-connect-succeeded', this.reportConnectSucceeded.bind(this), ipcMain)
+        ipcHandleNoResponse('webble-unsupported-device', this.reportUnsupportedDevice.bind(this), ipcMain)
+        ipcHandleNoResponse('webble-log', this.log.bind(this), ipcMain)
     }
 
     registerRenderer(spec, ipcRenderer) {
@@ -293,6 +401,10 @@ class WebBleFeature extends Feature {
 
         spec.webble.getMac = ipcCallSync('webble-get-mac', ipcRenderer)
         spec.webble.takeApproved = ipcCallSync('webble-take-approved', ipcRenderer)
+        spec.webble.reportProbeFailed = ipcCallNoResponse('webble-probe-failed', ipcRenderer)
+        spec.webble.reportConnectSucceeded = ipcCallNoResponse('webble-connect-succeeded', ipcRenderer)
+        spec.webble.reportUnsupportedDevice = ipcCallNoResponse('webble-unsupported-device', ipcRenderer)
+        spec.webble.log = ipcCallNoResponse('webble-log', ipcRenderer)
 
         // 'webble-services': binding supports setSupportedServices() (devices lib
         // announces its BLE service list — no desktop release needed for new services)

--- a/src/features/webble/feature.test.js
+++ b/src/features/webble/feature.test.js
@@ -10,6 +10,7 @@ jest.mock('../utils', () => ({
     ipcHandleNoResponse: jest.fn(),
     ipcHandleSync: jest.fn(),
     ipcCallSync: jest.fn(() => jest.fn()),
+    ipcCallNoResponse: jest.fn(() => jest.fn()),
     ipcSendEvent: jest.fn(),
 }))
 
@@ -18,8 +19,18 @@ jest.mock('./ipc-binding', () => {
     return { getInstance: jest.fn(() => ({ setApi })) }
 })
 
+jest.mock('./device-cache', () => ({
+    getInstance: jest.fn(() => ({
+        isGood: jest.fn().mockReturnValue(false),
+        isBad: jest.fn().mockReturnValue(false),
+        markGood: jest.fn(),
+        markBad: jest.fn(),
+        recordFailure: jest.fn(),
+    })),
+}))
+
 const { app } = require('electron')
-const { ipcHandleNoResponse, ipcHandleSync, ipcCallSync, ipcSendEvent } = require('../utils')
+const { ipcHandleNoResponse, ipcHandleSync, ipcCallSync, ipcCallNoResponse, ipcSendEvent } = require('../utils')
 const WebBleFeature = require('./feature')
 
 beforeEach(() => {
@@ -170,6 +181,128 @@ describe('WebBleFeature — connect', () => {
         feature.connect('D4:C9:BB:7D:CB:AF')
 
         expect(feature._triggerScanIteration).toHaveBeenCalled()
+    })
+
+    test('records the MAC as an explicitly requested (cooldown-exempt) device', () => {
+        feature.connect('D4:C9:BB:7D:CB:AF')
+        expect(feature.connectTargetMacs.has('D4:C9:BB:7D:CB:AF')).toBe(true)
+    })
+
+    test('persists the MAC as good, so it is preferred from the very next app launch', () => {
+        feature.connect('D4:C9:BB:7D:CB:AF')
+        expect(feature.deviceCache.markGood).toHaveBeenCalledWith('D4:C9:BB:7D:CB:AF')
+    })
+
+})
+
+// ── _inCooldown / reportProbeFailed ─────────────────────────────────────────────
+
+describe('WebBleFeature — _inCooldown / reportProbeFailed', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+    })
+
+    test('a device is not in cooldown by default', () => {
+        expect(feature._inCooldown('aa')).toBe(false)
+    })
+
+    test('reportProbeFailed puts a device into cooldown', () => {
+        feature.reportProbeFailed('aa')
+        expect(feature._inCooldown('aa')).toBe(true)
+    })
+
+    test('cooldown expires after PROBE_FAILURE_COOLDOWN', () => {
+        feature.reportProbeFailed('aa')
+        feature.probeCooldowns.set('aa', Date.now() - 1)   // simulate expiry
+        expect(feature._inCooldown('aa')).toBe(false)
+        expect(feature.probeCooldowns.has('aa')).toBe(false)   // cleaned up
+    })
+
+    test('a device explicitly requested via connect() is never in cooldown', () => {
+        feature.connectTargetMacs.add('aa')
+        feature.reportProbeFailed('aa')
+        expect(feature._inCooldown('aa')).toBe(false)
+        expect(feature.probeCooldowns.has('aa')).toBe(false)   // never even recorded
+    })
+
+    test('a device persisted as good (from a previous session) is never in cooldown', () => {
+        feature.deviceCache.isGood.mockReturnValue(true)
+        feature.reportProbeFailed('aa')   // not connectTargetMacs-exempt this session
+        expect(feature._inCooldown('aa')).toBe(false)
+    })
+
+    test('reportProbeFailed records the failure in the persisted device cache', () => {
+        feature.reportProbeFailed('aa', 'JBL PartyBox')
+        expect(feature.deviceCache.recordFailure).toHaveBeenCalledWith('aa', 'JBL PartyBox')
+    })
+
+    test('reportProbeFailed does not record a failure for an explicitly requested device', () => {
+        feature.connectTargetMacs.add('aa')
+        feature.reportProbeFailed('aa', 'Volt')
+        expect(feature.deviceCache.recordFailure).not.toHaveBeenCalled()
+    })
+
+})
+
+// ── reportConnectSucceeded ───────────────────────────────────────────────────────
+
+describe('WebBleFeature — reportConnectSucceeded', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+    })
+
+    test('persists the MAC as good', () => {
+        feature.reportConnectSucceeded('D4:C9:BB:7D:CB:AF', 'Volt')
+        expect(feature.deviceCache.markGood).toHaveBeenCalledWith('D4:C9:BB:7D:CB:AF', 'Volt')
+    })
+
+    test('exempts the MAC from cooldown for the rest of this session too', () => {
+        feature.reportConnectSucceeded('D4:C9:BB:7D:CB:AF', 'Volt')
+        expect(feature.connectTargetMacs.has('D4:C9:BB:7D:CB:AF')).toBe(true)
+    })
+
+})
+
+// ── reportUnsupportedDevice ───────────────────────────────────────────────────────
+
+describe('WebBleFeature — reportUnsupportedDevice', () => {
+
+    let feature
+
+    beforeEach(() => {
+        feature = new WebBleFeature()
+    })
+
+    test('blacklists the device immediately', () => {
+        feature.reportUnsupportedDevice('aa', 'JBL PartyBox')
+        expect(feature.deviceCache.markBad).toHaveBeenCalledWith('aa', 'JBL PartyBox')
+    })
+
+    test('does not blacklist an explicitly requested device', () => {
+        feature.connectTargetMacs.add('aa')
+        feature.reportUnsupportedDevice('aa', 'Volt')
+        expect(feature.deviceCache.markBad).not.toHaveBeenCalled()
+    })
+
+})
+
+// ── log (renderer log relay) ────────────────────────────────────────────────────
+
+describe('WebBleFeature — log', () => {
+
+    test('forwards the event to the main-process logger', () => {
+        const feature = new WebBleFeature()
+        feature.logger.logEvent = jest.fn()
+
+        feature.log({ message: 'GATT connecting to', device: 'Volt' })
+
+        expect(feature.logger.logEvent).toHaveBeenCalledWith({ message: 'GATT connecting to', device: 'Volt' })
     })
 
 })
@@ -351,6 +484,49 @@ describe('WebBleFeature — _onSelectBluetoothDevice', () => {
         expect(cb1).toHaveBeenCalledWith('aa')
         expect(cb2).not.toHaveBeenCalled()
         expect(feature.pendingCallback).toBe(cb2)
+    })
+
+    test('scanning: skips a device that is in cooldown, approves the next candidate', () => {
+        feature.scanning = true
+        feature.probeCooldowns.set('aa', Date.now() + 60000)
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa', 'bb'), cb)
+        expect(cb).toHaveBeenCalledWith('bb')
+    })
+
+    test('scanning: an explicitly-requested device is approved even though it is in cooldown', () => {
+        feature.scanning = true
+        feature.probeCooldowns.set('aa', Date.now() + 60000)
+        feature.connectTargetMacs.add('aa')
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa', 'bb'), cb)
+        expect(cb).toHaveBeenCalledWith('aa')
+    })
+
+    test('scanning: a device blacklisted in the persisted cache is never approved, even as the only candidate', () => {
+        feature.scanning = true
+        feature.deviceCache.isBad.mockImplementation(id => id === 'aa')
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), cb)
+        expect(cb).not.toHaveBeenCalled()
+        expect(feature.pendingCallback).toBe(cb)
+    })
+
+    test('scanning: a device persisted as good wins over an earlier, unclassified device in the same list', () => {
+        feature.scanning = true
+        feature.deviceCache.isGood.mockImplementation(id => id === 'bb')
+        const cb = jest.fn()
+        // 'aa' appears first in the array but 'bb' is the known-good device
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa', 'bb'), cb)
+        expect(cb).toHaveBeenCalledWith('bb')
+    })
+
+    test('scanning: falls back to a cooled-down device when nothing better is available (parked, not idle)', () => {
+        feature.scanning = true
+        feature.probeCooldowns.set('aa', Date.now() + 60000)
+        const cb = jest.fn()
+        feature._onSelectBluetoothDevice(makeEvent(), makeDeviceList('aa'), cb)
+        expect(cb).toHaveBeenCalledWith('aa')
     })
 
     test('scanning: approves second new device on subsequent event', () => {
@@ -535,7 +711,7 @@ describe('WebBleFeature — register', () => {
         expect(app.on).toHaveBeenCalledWith('web-contents-created', expect.any(Function))
     })
 
-    test('registers all four no-response IPC handlers', () => {
+    test('registers all no-response IPC handlers', () => {
         const feature = WebBleFeature.getInstance()
         feature.register({})
         const keys = ipcHandleNoResponse.mock.calls.map(c => c[0])
@@ -543,6 +719,10 @@ describe('WebBleFeature — register', () => {
         expect(keys).toContain('webble-stop-scan')
         expect(keys).toContain('webble-connect')
         expect(keys).toContain('webble-disconnect')
+        expect(keys).toContain('webble-probe-failed')
+        expect(keys).toContain('webble-connect-succeeded')
+        expect(keys).toContain('webble-unsupported-device')
+        expect(keys).toContain('webble-log')
     })
 
     test('registers webble-get-mac and webble-take-approved as sync handlers', () => {
@@ -649,6 +829,10 @@ describe('WebBleFeature — registerRenderer', () => {
         expect(typeof spec.webble.disconnect).toBe('function')
         expect(typeof spec.webble.getMac).toBe('function')
         expect(typeof spec.webble.takeApproved).toBe('function')
+        expect(typeof spec.webble.reportProbeFailed).toBe('function')
+        expect(typeof spec.webble.reportConnectSucceeded).toBe('function')
+        expect(typeof spec.webble.reportUnsupportedDevice).toBe('function')
+        expect(typeof spec.webble.log).toBe('function')
     })
 
     test('wires getMac and takeApproved via ipcCallSync', () => {
@@ -657,6 +841,16 @@ describe('WebBleFeature — registerRenderer', () => {
         const syncKeys = ipcCallSync.mock.calls.map(c => c[0])
         expect(syncKeys).toContain('webble-get-mac')
         expect(syncKeys).toContain('webble-take-approved')
+    })
+
+    test('wires reportProbeFailed, reportConnectSucceeded, reportUnsupportedDevice and log via ipcCallNoResponse', () => {
+        const feature = WebBleFeature.getInstance()
+        feature.registerRenderer(spec, ipcRenderer)
+        const keys = ipcCallNoResponse.mock.calls.map(c => c[0])
+        expect(keys).toContain('webble-probe-failed')
+        expect(keys).toContain('webble-connect-succeeded')
+        expect(keys).toContain('webble-unsupported-device')
+        expect(keys).toContain('webble-log')
     })
 
     test('announces webble capabilities', () => {

--- a/src/features/webble/ipc-binding.js
+++ b/src/features/webble/ipc-binding.js
@@ -40,6 +40,7 @@ class WebBleIpcBinding extends EventEmitter {
         this.api = null
         this.stopRequested = false
         this._stateEmitted = false
+        this._serverDebug = false
 
         // Device identity:
         // - The MAC address (deviceId that main captures from select-bluetooth-device)
@@ -83,6 +84,21 @@ class WebBleIpcBinding extends EventEmitter {
         return this.api
     }
 
+    /**
+     * Structured-log relay to main (see feature.js#log for why this can't just be a
+     * local EventLogger instance). Best-effort: falls back to nothing if the api
+     * surface isn't wired yet (e.g. in tests that don't stub it).
+     *
+     * debug:true marks routine/expected events (still sent to production logs for
+     * now, while this binding is under active investigation) so they can be filtered
+     * out later without touching call sites. Failures are never marked debug.
+     */
+    _log(event) {
+        if (event?.debug && !this._serverDebug)
+            return
+        this.getApi()?.log?.(event)
+    }
+
     get state() {
         return this._state
     }
@@ -93,7 +109,9 @@ class WebBleIpcBinding extends EventEmitter {
 
     pauseLogging() {}
     resumeLogging() {}
-    setServerDebug(_enabled) {}
+    setServerDebug(_enabled) {
+        this._serverDebug = _enabled
+    }
 
     /**
      * Called by the devices lib (feature-detected, optional in its BleBinding
@@ -113,7 +131,7 @@ class WebBleIpcBinding extends EventEmitter {
         }
         this._knownServiceUUIDs = [...byFullUUID.values()]
         this._optionalServices = [...byFullUUID.keys()]
-        console.log('[WebBLE] supported services set:', this._optionalServices.length)
+        this._log({ message: 'supported services set', count: this._optionalServices.length, debug: true })
     }
 
     on(event, callback) {
@@ -145,7 +163,7 @@ class WebBleIpcBinding extends EventEmitter {
             if (seen.has(entry)) continue
             seen.add(entry)
             if (!entry.probed || !entry.name || !entry.mac) continue
-            console.log('[WebBLE] startScanning: re-emitting', entry.name, entry.serviceUuids)
+            this._log({ message: 'startScanning: re-emitting', device: entry.name, serviceUuids: entry.serviceUuids, debug: true })
             const peripheral = this._createPeripheral({ id: entry.mac, name: entry.name, serviceUuids: entry.serviceUuids })
             this.emit('discover', peripheral)
         }
@@ -159,7 +177,7 @@ class WebBleIpcBinding extends EventEmitter {
     async _discoverApprovedDevices() {
         try {
             const devices = await navigator.bluetooth.getDevices()
-            console.log('[WebBLE] getDevices returned', devices.length, 'device(s)', devices.map(d => d.name))
+            this._log({ message: 'getDevices returned', count: devices.length, devices: devices.map(d => d.name), debug: true })
             for (const device of devices) {
                 if (this.stopRequested) break
                 const entry = this._deviceCache.get(device.id)
@@ -168,7 +186,7 @@ class WebBleIpcBinding extends EventEmitter {
                 }
             }
         } catch (err) {
-            console.log('[WebBLE] getDevices failed:', err?.message)
+            this._log({ message: 'getDevices failed', error: err?.message })
         }
     }
 
@@ -228,7 +246,7 @@ class WebBleIpcBinding extends EventEmitter {
      * share the same name.
      */
     async _processDiscoveredDevice(device, approved = false) {
-        console.log('[WebBLE] _processDiscoveredDevice', device.name, 'approved:', approved)
+        this._log({ message: '_processDiscoveredDevice', device: device.name, approved, debug: true })
 
         let mac = null
         if (approved) {
@@ -241,7 +259,7 @@ class WebBleIpcBinding extends EventEmitter {
         // Anonymous devices — fitness devices always have names and the adapter drops
         // nameless peripherals anyway. Skipping GATT here avoids wasting ~1s per device.
         if (!device.name) {
-            console.log('[WebBLE] skipping anonymous device', device.id)
+            this._log({ message: 'skipping anonymous device', deviceId: device.id, debug: true })
             entry.probed = true
             return
         }
@@ -250,7 +268,7 @@ class WebBleIpcBinding extends EventEmitter {
         // opaque id may have changed, but the services are known: re-emit from cache.
         if (entry.probed) {
             const id = entry.mac ?? entry.opaqueId
-            console.log('[WebBLE] re-emitting known device', entry.name, 'id:', id)
+            this._log({ message: 're-emitting known device', device: entry.name, id, debug: true })
             const peripheral = this._createPeripheral({ id, name: entry.name, serviceUuids: entry.serviceUuids })
             this.emit('discover', peripheral)
             return
@@ -260,10 +278,26 @@ class WebBleIpcBinding extends EventEmitter {
         // has been handed over; don't delay the connection with a GATT probe.
         if (hadPendingConnect) return
 
+        // Every device is probed live, even a known-good one — some devices (e.g. a
+        // rower whose FTMS service only appears once its GATT server has fully
+        // initialised) report different, incomplete service sets depending on
+        // exactly when they're probed. Reusing a remembered list across launches
+        // risks permanently hiding a capability the device actually has, so the
+        // "good" cache only ever influences chooser priority (see feature.js), never
+        // what gets announced here.
         const serviceUuids = await this._probeServices(device)
         if (serviceUuids === null) {
-            // probe failed or timed out — leave probed=false so the next encounter retries
+            // probe failed or timed out — leave probed=false so the next encounter retries.
+            // Tell main so it can cool this device down instead of re-offering it (and
+            // burning another full probe) on every subsequent chooser slot.
+            this.getApi().reportProbeFailed?.(entry.mac ?? entry.opaqueId, device.name)
             return
+        }
+        // The probe succeeded (we connected and read services) but none of them are
+        // ours — a stronger signal than a mere connect failure: this is confirmed to
+        // be the wrong kind of device, not just a flaky one.
+        if (!this._hasKnownService(serviceUuids) && !device.name?.startsWith('Zwift')) {
+            this.getApi().reportUnsupportedDevice?.(entry.mac ?? entry.opaqueId, device.name)
         }
         entry.serviceUuids = serviceUuids
         entry.probed = true
@@ -276,7 +310,7 @@ class WebBleIpcBinding extends EventEmitter {
             // Release the probe connection: a GATT-connected device stops advertising
             // and would never show up in the scan loop's chooser to get its MAC.
             try { device.gatt.disconnect() } catch {}
-            console.log('[WebBLE] deferring emit for', device.name, '— MAC not known yet')
+            this._log({ message: 'deferring emit — MAC not known yet', device: device.name, debug: true })
             return
         }
 
@@ -288,7 +322,7 @@ class WebBleIpcBinding extends EventEmitter {
         this._scheduleGattRelease(entry)
 
         const id = entry.mac ?? entry.opaqueId
-        console.log('[WebBLE] emitting discover for', device.name, 'services:', serviceUuids, 'id:', id)
+        this._log({ message: 'emitting discover for', device: device.name, services: serviceUuids, id, debug: true })
         const peripheral = this._createPeripheral({ id, name: device.name, serviceUuids })
         this.emit('discover', peripheral)
     }
@@ -299,10 +333,14 @@ class WebBleIpcBinding extends EventEmitter {
      * probe failed or timed out.
      */
     async _probeServices(device) {
-        console.log('[WebBLE] connecting to', device.name, 'for service discovery')
+        this._log({ message: 'GATT connecting to', device: device.name, debug: true })
         try {
-            const server = await this._withTimeout(device.gatt.connect(), this._probeTimeoutMs, 'GATT probe connect')
-            console.log('[WebBLE] GATT connected to', device.name)
+            // reuses the same retry-with-backoff helper the real pairing connect uses
+            // (_gattConnectRetries attempts) — a one-off GATT hiccup during discovery
+            // shouldn't be treated as a permanent failure any more than it would be
+            // when actually connecting
+            const server = await this._gattConnect(device)
+            this._log({ message: 'GATT connected to', device: device.name, debug: true })
 
             const services = await this._withTimeout(this._getServerServices(server), this._probeTimeoutMs, 'service discovery')
 
@@ -315,10 +353,15 @@ class WebBleIpcBinding extends EventEmitter {
             // connection is kept for an imminent connect or released
             return serviceUuids
         } catch (err) {
-            console.log('[WebBLE] GATT service discovery failed for', device.name, err?.message)
+            this._log({ message: 'GATT probe failed', device: device.name, error: err?.message })
             try { device.gatt.disconnect() } catch {}
             return null
         }
+    }
+
+    /** Whether a probed service list includes any of the services we actually use. */
+    _hasKnownService(serviceUuids) {
+        return serviceUuids.some(u => this._knownServiceUUIDs.some(k => toFullUUID(k) === toFullUUID(u)))
     }
 
     /**
@@ -354,7 +397,7 @@ class WebBleIpcBinding extends EventEmitter {
             if (entry.inUse) return
             try {
                 if (entry.device?.gatt?.connected) {
-                    console.log('[WebBLE] releasing unclaimed GATT connection for', entry.name)
+                    this._log({ message: 'releasing unclaimed GATT connection', device: entry.name, debug: true })
                     entry.device.gatt.disconnect()
                 }
             } catch {}
@@ -445,7 +488,7 @@ class WebBleIpcBinding extends EventEmitter {
             device = await this._waitForDevice(peripheral.id)
         }
 
-        console.log('[WebBLE] connectPeripheral', peripheral.name, 'via', source)
+        this._log({ message: 'connectPeripheral', device: peripheral.name, source, debug: true })
 
         // claim the device: a probe connection kept alive for this device is reused,
         // and the grace-period release must not tear down an in-use connection
@@ -460,7 +503,13 @@ class WebBleIpcBinding extends EventEmitter {
 
         peripheral._server = await this._gattConnect(device)
         peripheral.state = 'connected'
-        console.log('[WebBLE] connectPeripheral done', peripheral.name)
+        this._log({ message: 'connectPeripheral done', device: peripheral.name, debug: true })
+
+        // The real "this MAC is a device we actually use" signal — hit regardless of
+        // which source resolved it above (unlike feature.js's connect(), which is
+        // only reached via the 'approval' source and rarely fires in a normal
+        // session where the device was already found by the scan loop).
+        this.getApi().reportConnectSucceeded?.(entry.mac ?? peripheral.id, peripheral.name)
     }
 
     _waitForDevice(id) {
@@ -488,7 +537,7 @@ class WebBleIpcBinding extends EventEmitter {
                 return await this._withTimeout(device.gatt.connect(), this._gattConnectTimeoutMs, 'GATT connect')
             } catch (err) {
                 lastErr = err
-                console.log('[WebBLE] GATT connect attempt', attempt, 'failed for', device.name, err?.message)
+                this._log({ message: 'GATT connect attempt failed', attempt, device: device.name, error: err?.message })
                 if (attempt < this._gattConnectRetries)
                     await new Promise(res => setTimeout(res, this._gattRetryDelayMs))
             }
@@ -517,13 +566,13 @@ class WebBleIpcBinding extends EventEmitter {
      */
     async _reviveDeadServer(peripheral) {
         if (!peripheral._device || peripheral._server?.connected) return false
-        console.log('[WebBLE] GATT server dead for', peripheral.name, '— reconnecting')
+        this._log({ message: 'GATT server dead — reconnecting', device: peripheral.name, debug: true })
         try {
             peripheral._server = await this._gattConnect(peripheral._device)
             peripheral.state = 'connected'
             return true
         } catch (err) {
-            console.log('[WebBLE] GATT reconnect failed for', peripheral.name, err?.message)
+            this._log({ message: 'GATT reconnect failed', device: peripheral.name, error: err?.message })
             return false
         }
     }
@@ -552,7 +601,7 @@ class WebBleIpcBinding extends EventEmitter {
             peripheral.state = 'connected'
             return true
         } catch (err) {
-            console.log('[WebBLE] on-demand GATT connect failed for', peripheral.name, err?.message)
+            this._log({ message: 'on-demand GATT connect failed', device: peripheral.name, error: err?.message })
             return false
         }
     }

--- a/src/features/webble/ipc-binding.test.js
+++ b/src/features/webble/ipc-binding.test.js
@@ -61,6 +61,10 @@ const makeApi = (overrides = {}) => ({
     disconnect: jest.fn(),
     getMac: jest.fn().mockReturnValue(null),
     takeApproved: jest.fn().mockReturnValue(null),
+    reportProbeFailed: jest.fn(),
+    reportConnectSucceeded: jest.fn(),
+    reportUnsupportedDevice: jest.fn(),
+    log: jest.fn(),
     ...overrides,
 })
 
@@ -215,8 +219,46 @@ describe('WebBleIpcBinding — no-op methods', () => {
         expect(() => new WebBleIpcBinding().resumeLogging()).not.toThrow()
     })
 
-    test('setServerDebug does not throw', () => {
-        expect(() => new WebBleIpcBinding().setServerDebug(true)).not.toThrow()
+})
+
+// ── _log / setServerDebug ─────────────────────────────────────────────────────
+
+describe('WebBleIpcBinding — _log / setServerDebug', () => {
+
+    let binding, api
+
+    beforeEach(() => {
+        api = makeApi()
+        binding = new WebBleIpcBinding()
+        binding.setApi(api)
+    })
+
+    test('debug:true events are suppressed by default', () => {
+        binding._log({ message: 'routine', debug: true })
+        expect(api.log).not.toHaveBeenCalled()
+    })
+
+    test('non-debug events are always relayed, regardless of server-debug state', () => {
+        binding._log({ message: 'GATT probe failed' })
+        expect(api.log).toHaveBeenCalledWith({ message: 'GATT probe failed' })
+    })
+
+    test('setServerDebug(true) lets debug:true events through', () => {
+        binding.setServerDebug(true)
+        binding._log({ message: 'routine', debug: true })
+        expect(api.log).toHaveBeenCalledWith({ message: 'routine', debug: true })
+    })
+
+    test('setServerDebug(false) re-suppresses debug:true events', () => {
+        binding.setServerDebug(true)
+        binding.setServerDebug(false)
+        binding._log({ message: 'routine', debug: true })
+        expect(api.log).not.toHaveBeenCalled()
+    })
+
+    test('does not throw when api.log is unavailable', () => {
+        delete api.log
+        expect(() => binding._log({ message: 'x' })).not.toThrow()
     })
 
 })
@@ -425,6 +467,7 @@ describe('WebBleIpcBinding — _processDiscoveredDevice', () => {
         api = makeApi()
         binding = new WebBleIpcBinding()
         binding.setApi(api)
+        binding._gattRetryDelayMs = 1   // probe now retries via _gattConnect — keep tests fast
     })
 
     test('skips anonymous devices without GATT or emit and marks them probed', async () => {
@@ -597,9 +640,25 @@ describe('WebBleIpcBinding — _processDiscoveredDevice', () => {
         expect(discovered[0].advertisement.serviceUuids).not.toContain('180d')
     })
 
+    test('probe failure: retries within the same probe (via _gattConnect) before giving up', async () => {
+        const device = makeBleDevice('dev-1', 'KICKR CORE')
+        device.gatt.connect
+            .mockRejectedValueOnce(new Error('flaky'))
+            .mockResolvedValueOnce(makeGattServer(['1826']))
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(device.gatt.connect).toHaveBeenCalledTimes(2)
+        expect(discovered).toHaveLength(1)
+        expect(discovered[0].advertisement.serviceUuids).toEqual(['1826'])
+    })
+
     test('probe failure: emits nothing and stays retryable — succeeds on next encounter', async () => {
         const device = makeBleDevice('dev-1', 'KICKR CORE')
-        device.gatt.connect.mockRejectedValueOnce(new Error('connection failed'))
+        device.gatt.connect.mockRejectedValue(new Error('connection failed'))   // fails every attempt/retry
 
         const discovered = []
         binding.on('discover', p => discovered.push(p))
@@ -617,8 +676,70 @@ describe('WebBleIpcBinding — _processDiscoveredDevice', () => {
         expect(discovered[0].advertisement.serviceUuids).toEqual(['1826'])
     })
 
+    test('probe failure: reports the MAC (or opaque id) to main so it can be cooled down', async () => {
+        api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
+        const device = makeBleDevice('opaque-1', 'Volt')
+        device.gatt.connect.mockRejectedValue(new Error('GATT probe connect timeout'))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.reportProbeFailed).toHaveBeenCalledWith('D4:C9:BB:7D:CB:AF', 'Volt')
+    })
+
+    test('probe success: does not report a probe failure', async () => {
+        const device = makeBleDevice('dev-1', 'KICKR', makeGattServer(['1826']))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.reportProbeFailed).not.toHaveBeenCalled()
+    })
+
+    test('probe failure: relays a log event to main via api.log, not marked debug (visible in structured logs, unlike console.log)', async () => {
+        const device = makeBleDevice('dev-1', 'Volt')
+        device.gatt.connect.mockRejectedValue(new Error('GATT probe connect timeout'))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'GATT probe failed', device: 'Volt' })
+        )
+        const failureEvent = api.log.mock.calls.map(c => c[0]).find(e => e.message === 'GATT probe failed')
+        expect(failureEvent.debug).toBeUndefined()
+    })
+
+    test('probe success: relays connecting/connected log events to main via api.log, marked debug:true', async () => {
+        binding.setServerDebug(true)
+        const device = makeBleDevice('dev-1', 'Volt', makeGattServer(['1826']))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'GATT connecting to', device: 'Volt', debug: true })
+        )
+        expect(api.log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'GATT connected to', device: 'Volt', debug: true })
+        )
+    })
+
+    test('logging is best-effort: does not throw when api.log is unavailable (older shell)', async () => {
+        delete api.log
+        const device = makeBleDevice('dev-1', 'Volt')
+        device.gatt.connect.mockRejectedValue(new Error('boom'))
+
+        await expect(binding._processDiscoveredDevice(device, true)).resolves.not.toThrow()
+    })
+
+    test('probe failure: does not throw when api.reportProbeFailed is unavailable (older shell)', async () => {
+        delete api.reportProbeFailed
+        const device = makeBleDevice('dev-1', 'KICKR CORE')
+        device.gatt.connect.mockRejectedValue(new Error('boom'))
+
+        await expect(binding._processDiscoveredDevice(device, true)).resolves.not.toThrow()
+    })
+
     test('probe timeout: a hanging GATT connect does not block processing forever', async () => {
-        binding._probeTimeoutMs = 50
+        binding._gattConnectTimeoutMs = 50
+        binding._gattConnectRetries = 1
         const device = makeBleDevice('dev-1', 'Stuck Device')
         device.gatt.connect.mockReturnValue(new Promise(() => {}))   // never settles
 
@@ -679,6 +800,51 @@ describe('WebBleIpcBinding — _processDiscoveredDevice', () => {
         await binding._processDiscoveredDevice(device, true)
 
         expect(device.gatt.disconnect).toHaveBeenCalled()
+    })
+
+    test('probe succeeds but no known service matches: reports the device as unsupported', async () => {
+        // e.g. a JBL speaker — connects fine, but its services are nothing we use
+        const server = makeGattServer(['110b'])   // A2DP Audio Sink — not a fitness service
+        const device = makeBleDevice('dev-1', 'JBL PartyBox Club 120', server)
+
+        const discovered = []
+        binding.on('discover', p => discovered.push(p))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        // still emitted — interface.ts does its own filtering too — but main is told
+        // so it can blacklist the device outright instead of re-offering it
+        expect(discovered).toHaveLength(1)
+        expect(api.reportUnsupportedDevice).toHaveBeenCalledWith('dev-1', 'JBL PartyBox Club 120')
+    })
+
+    test('probe succeeds with a matching known service: does not report unsupported', async () => {
+        const server = makeGattServer(['1826'])
+        const device = makeBleDevice('dev-1', 'KICKR CORE', server)
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.reportUnsupportedDevice).not.toHaveBeenCalled()
+    })
+
+    test('Zwift-named devices are never reported unsupported, even with no matching services', async () => {
+        const server = makeGattServer(['110b'])
+        const device = makeBleDevice('dev-1', 'Zwift Cog', server)
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.reportUnsupportedDevice).not.toHaveBeenCalled()
+    })
+
+    test('a known-good device is still probed live — persisted status never skips the real probe', async () => {
+        // e.g. a rower whose FTMS service only appears once fully initialised — a
+        // remembered service list from a previous session could be stale/incomplete
+        api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
+        const device = makeBleDevice('opaque-1', 'Volt', makeGattServer(['1826']))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(device.gatt.connect).toHaveBeenCalled()
     })
 
     test('stores device and serviceUuids in cache after discovery', async () => {
@@ -765,6 +931,17 @@ describe('WebBleIpcBinding — _processDiscoveredDevice', () => {
         expect(discovered).toHaveLength(0)
     })
 
+    test('logs entry into _processDiscoveredDevice as debug:true', async () => {
+        binding.setServerDebug(true)
+        const device = makeBleDevice('dev-1', 'KICKR', makeGattServer(['1826']))
+
+        await binding._processDiscoveredDevice(device, true)
+
+        expect(api.log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: '_processDiscoveredDevice', device: 'KICKR', approved: true, debug: true })
+        )
+    })
+
     test('discovered peripheral has Noble-compatible shape', async () => {
         const server = makeGattServer(['180d'])
         const device = makeBleDevice('dev-1', 'HRM Pro', server)
@@ -825,6 +1002,36 @@ describe('WebBleIpcBinding — _connectPeripheral', () => {
         expect(peripheral._server).toBeDefined()
     })
 
+    test('reports the successful connect to main — even via the common "already cached" source', async () => {
+        const cachedDevice = makeBleDevice('dev-1')
+        binding._cacheDevice(cachedDevice, null)
+
+        const peripheral = getPeripheral('dev-1', 'Trainer')
+        await peripheral.connectAsync()
+
+        expect(api.reportConnectSucceeded).toHaveBeenCalledWith('dev-1', 'Trainer')
+    })
+
+    test('does not report a connect success when the connect fails', async () => {
+        binding._gattConnectRetries = 1
+        const device = makeBleDevice('dev-1')
+        device.gatt.connect.mockRejectedValue(new Error('unreachable'))
+        binding._cacheDevice(device, null)
+
+        const peripheral = getPeripheral()
+        await expect(peripheral.connectAsync()).rejects.toThrow('unreachable')
+
+        expect(api.reportConnectSucceeded).not.toHaveBeenCalled()
+    })
+
+    test('does not throw when api.reportConnectSucceeded is unavailable (older shell)', async () => {
+        delete api.reportConnectSucceeded
+        const cachedDevice = makeBleDevice('dev-1')
+        binding._cacheDevice(cachedDevice, null)
+
+        await expect(getPeripheral().connectAsync()).resolves.not.toThrow()
+    })
+
     test('resolves the cache by MAC when the device was approved with one (bug 1 regression)', async () => {
         // scan loop discovered Volt: opaque id + MAC recorded via takeApproved
         api.takeApproved.mockReturnValue('D4:C9:BB:7D:CB:AF')
@@ -841,6 +1048,8 @@ describe('WebBleIpcBinding — _connectPeripheral', () => {
         expect(global.navigator.bluetooth.requestDevice).not.toHaveBeenCalled()
         expect(peripheral.state).toBe('connected')
         expect(peripheral._server).toBeDefined()
+        // reported by MAC, not the stale opaque id from the earlier discovery
+        expect(api.reportConnectSucceeded).toHaveBeenCalledWith('D4:C9:BB:7D:CB:AF', 'Volt')
     })
 
     test('falls back to getDevices exact-id match when device not in cache', async () => {
@@ -923,6 +1132,37 @@ describe('WebBleIpcBinding — _connectPeripheral', () => {
 
         expect(device.gatt.connect).toHaveBeenCalledTimes(2)
         expect(peripheral.state).toBe('connected')
+    })
+
+    test('logs each failed GATT connect attempt, not marked debug', async () => {
+        const device = makeBleDevice('dev-1', 'Trainer')
+        device.gatt.connect
+            .mockRejectedValueOnce(new Error('flaky'))
+            .mockResolvedValueOnce(makeGattServer())
+        binding._cacheDevice(device, null)
+
+        await getPeripheral('dev-1', 'Trainer').connectAsync()
+
+        expect(api.log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'GATT connect attempt failed', attempt: 1, device: 'Trainer', error: 'flaky' })
+        )
+        const attemptEvent = api.log.mock.calls.map(c => c[0]).find(e => e.message === 'GATT connect attempt failed')
+        expect(attemptEvent.debug).toBeUndefined()
+    })
+
+    test('logs connectPeripheral start and completion as debug:true', async () => {
+        binding.setServerDebug(true)
+        const device = makeBleDevice('dev-1', 'Trainer')
+        binding._cacheDevice(device, null)
+
+        await getPeripheral('dev-1', 'Trainer').connectAsync()
+
+        expect(api.log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'connectPeripheral', device: 'Trainer', source: 'cache', debug: true })
+        )
+        expect(api.log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'connectPeripheral done', device: 'Trainer', debug: true })
+        )
     })
 
     test('rejects when all GATT connect attempts fail', async () => {
@@ -1240,6 +1480,35 @@ describe('WebBleIpcBinding — dead-server recovery', () => {
         const services = await peripheral.discoverServicesAsync(['1826'])
 
         expect(services).toEqual([])
+    })
+
+    test('logs the dead-server detection as debug:true, and a failed reconnect as not debug', async () => {
+        // connected:undefined (not explicitly false) — _ensureServer treats this as
+        // usable and skips its own reconnect; only _reviveDeadServer's empty-results
+        // check catches it, which is the actual "looks alive, isn't" race this guards
+        binding.setServerDebug(true)
+        binding._gattConnectRetries = 1
+        const device = makeBleDevice('dev-1', 'Volt')
+        device.gatt.connect.mockRejectedValue(new Error('unreachable'))
+
+        const peripheral = getPeripheral()
+        peripheral._device = device
+        peripheral._server = {
+            connected: undefined,
+            getPrimaryService: jest.fn().mockRejectedValue(new Error('GATT Server is disconnected')),
+        }
+
+        const services = await peripheral.discoverServicesAsync(['1826'])
+
+        expect(services).toEqual([])
+        expect(binding.getApi().log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'GATT server dead — reconnecting', device: 'Volt', debug: true })
+        )
+        expect(binding.getApi().log).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'GATT reconnect failed', device: 'Volt', error: 'unreachable' })
+        )
+        const reconnectFailedEvent = binding.getApi().log.mock.calls.map(c => c[0]).find(e => e.message === 'GATT reconnect failed')
+        expect(reconnectFailedEvent.debug).toBeUndefined()
     })
 
 })


### PR DESCRIPTION
## Summary

On Linux (WebBLE), a device whose GATT probe timed out during discovery failed completely silently and was never retried, while a nearby non-fitness BLE device could keep winning the chooser's next slot indefinitely — starving real, configured devices further back in the queue until their pairing timeout expired. This makes device discovery reliable, visible, and biased towards the devices the app actually uses.

## What changed

- **Retry**: `_probeServices` now uses the existing `_gattConnect` backoff helper instead of a single bare `device.gatt.connect()` attempt, so a one-off GATT hiccup doesn't permanently drop a device for the rest of the scan session.
- **Visibility**: the whole probe pipeline in `ipc-binding.js` previously logged via `console.log` only — invisible in production, because a renderer-local `EventLogger` has no adapters registered (adapters are wired up in the main process and separately in web-ui's bundle; `ipc-binding.js` is loaded via the preload's own `require()` graph, a third, disconnected module instance). Log events are now relayed to main over a new `webble-log` IPC channel. Routine events are tagged `debug: true` and suppressed by default (toggle via `setServerDebug`); failures are never suppressed.
- **Session cooldown**: a device that just failed its probe is excluded from the next chooser round (unless nothing better is available) instead of competing on equal footing with everything else — but a device the app explicitly asked to connect to is never cooled down.
- **Cross-launch reputation** (`device-cache.js`, new): good/bad status per MAC is persisted to `webble-devices.json`, so a known device (e.g. your trainer) is preferred from the very first scan of a new session, and a device confirmed to be the wrong kind (e.g. a nearby speaker) is never offered again. Deliberately does **not** cache service lists — some devices (e.g. a rower whose FTMS service only appears once its GATT server has fully initialised) report an incomplete service set depending on exactly when they're probed, so every discovery still gets a live probe; the cache only influences chooser ordering.
- **Immediate blacklist for wrong-type devices**: a device that connects successfully but reports none of our known services is blacklisted right away, rather than waiting for repeated connection failures like a transient GATT error would.
- Chooser selection in `_onSelectBluetoothDevice` is now tiered: known-good devices win regardless of list order, blacklisted devices are excluded outright, and a cooled-down device is only tried as a last resort instead of leaving the chooser idle.

## Test plan

- [x] `npm test` — 394 tests passing across the full suite, including new/updated coverage in `feature.test.js`, `ipc-binding.test.js`, and new `device-cache.test.js`
- [x] Manual verification with real BLE hardware (multiple configured devices, including a device with known service-initialization delays) — not yet done in this session