### PR TITLE
chore: ignore @electron/fuses v2 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "npm" 
+  - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # @electron/fuses v2 requires @electron-forge/plugin-fuses v8, which is
+      # still alpha-only (see PR #190). Revisit once electron-forge 8 is stable.
+      - dependency-name: "@electron/fuses"
+        versions: [">=2.0.0"]


### PR DESCRIPTION
## Summary
- Adds a dependabot ignore rule for `@electron/fuses` v2+.

## Why
PR #190 (bump `@electron/fuses` 1.8.0 → 2.1.3) failed manual production builds with an ERESOLVE conflict: `@electron-forge/plugin-fuses@7.11.2` (stable) only accepts `@electron/fuses@^1.0.0` as a peer. Support for `@electron/fuses@^2.0.0` only exists in `@electron-forge/plugin-fuses@8.0.0-alpha.10` — electron-forge 8 has no stable release yet.

Rather than let Dependabot keep re-raising an update we can't actually take, this ignores `@electron/fuses` v2+ until electron-forge 8 goes stable, at which point the whole electron-forge toolchain (cli, makers, plugins) should be bumped together.

## Test plan
- [x] N/A — config-only change, no build impact