### PR TITLE
fix: Windows signing step reads the certificate from the environment

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -39,11 +39,24 @@ jobs:
       if: ${{ inputs.sign_windows == true }}
       shell: pwsh
       env:
-        SETTINGS_FILE: ${{ secrets.CERT_WINDOWS }}
+        CERT_WINDOWS: ${{ secrets.CERT_WINDOWS }}
       run: |
-        New-Item -ItemType Directory -Force -Path .\certs
-        $encodedBytes = [System.Convert]::FromBase64String("${{ secrets.CERT_WINDOWS }}");      
-        Set-Content .\certs\installer.pfx -Value $encodedBytes -AsByteStream;
+        # Read the certificate from the environment rather than interpolating it into
+        # the script: base64 of a .pfx is line-wrapped by both `base64` and
+        # `certutil -encode`, and a multi-line value pasted into the script text is at
+        # the mercy of the PowerShell parser. It also keeps the secret out of the
+        # generated script file.
+        if ([string]::IsNullOrWhiteSpace($env:CERT_WINDOWS)) {
+          throw "CERT_WINDOWS secret is empty - cannot sign the installer"
+        }
+        New-Item -ItemType Directory -Force -Path .\certs | Out-Null
+        # WriteAllBytes rather than Set-Content -AsByteStream: no encoding or
+        # line-ending handling sits between the decoded bytes and the .pfx.
+        $b64 = $env:CERT_WINDOWS -replace '\s', ''
+        [System.IO.File]::WriteAllBytes(
+          (Join-Path (Get-Location) 'certs\installer.pfx'),
+          [System.Convert]::FromBase64String($b64)
+        )
         dir .\certs
 
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary

The `Generate certificate file from secret` step in `win-build.yml` declared an env var named `SETTINGS_FILE` holding the code-signing certificate, then ignored it and interpolated `${{ secrets.CERT_WINDOWS }}` straight into the PowerShell script. The step is gated behind the `sign_windows` input and no certificate secret exists yet, so it has never run — this is a fix ahead of the first signed build, not a regression report.

Found while sweeping every workflow in the workspace after the same secret-to-env-var refactor broke the Android build in incyclist/mobile#440.

## What changed

`.github/workflows/win-build.yml`, one step:

- Env var renamed `SETTINGS_FILE` → `CERT_WINDOWS` and actually read, instead of the secret being interpolated into the script text. Base64 of a `.pfx` is line-wrapped by both `base64` and `certutil -encode`, and a multi-line value pasted into a double-quoted PowerShell string leaves the outcome to the parser. It also keeps the certificate out of the generated script file.
- An absent or empty secret now fails the step with a clear message, rather than producing a zero-byte `installer.pfx` and pushing the failure downstream into signing, where it reads as a certificate problem.
- Line wrapping is stripped before decoding, and the bytes are written with `[System.IO.File]::WriteAllBytes` rather than `Set-Content -AsByteStream`, so no encoding or line-ending handling sits between the decode and the file.

## Test plan

- [x] YAML parses; the step's `env` / `shell` / `if` / `run` resolve as intended
- [x] No `${{ secrets.* }}` remains inside any `run:` block in this file — all four secrets are `env:` declarations
- [x] `npm test` — 25 suites, 413 tests pass (unrelated to a YAML change, run per the repo workflow)
- [ ] **Not executed end to end.** No `CERT_WINDOWS` secret is available yet and the step cannot run without one, so the PowerShell logic is reviewed rather than run. Worth watching on the first `sign_windows: true` dispatch.
